### PR TITLE
clang compile

### DIFF
--- a/configure.inc
+++ b/configure.inc
@@ -874,7 +874,7 @@ say(char *w, char *v)
 			: "s:@%s@:%s:g\n", w, v);
 }
 
-void
+int
 main(argc, argv)
 char **argv;
 {

--- a/main.c
+++ b/main.c
@@ -59,7 +59,7 @@ complain(char *fmt, ...)
 }
 
 
-float
+int
 main(int argc, char **argv)
 {
     int opt;

--- a/makepage.c
+++ b/makepage.c
@@ -22,7 +22,7 @@ basename(char *p)
 
 char *pgm = "makepage";
 
-float
+int
 main(argc, argv)
 int argc;
 char **argv;

--- a/mkd2html.c
+++ b/mkd2html.c
@@ -65,7 +65,7 @@ fail(char *why, ...)
 }
 
 
-void
+int
 main(argc, argv)
 char **argv;
 {

--- a/theme.c
+++ b/theme.c
@@ -499,7 +499,7 @@ spin(FILE *template, MMIOT *doc, FILE *output)
 } /* spin */
 
 
-void
+int
 main(argc, argv)
 char **argv;
 {

--- a/tools/cols.c
+++ b/tools/cols.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+int
 main(argc, argv)
 char **argv;
 {

--- a/tools/echo.c
+++ b/tools/echo.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 
+int
 main(argc, argv)
 char **argv;
 {


### PR DESCRIPTION
I have `CC=clang` in my env, so discount configure failed like:

```
defining WORD & DWORD scalar types ** FAILED **
```

and compile failed with:

```
main.c:62:1: error: 'main' must return 'int'
float
^
```

I would imagine your use of void and float return types are intentional, so feel free to ignore this. But, would be nice to support clang if possible. thanks!
