### PR TITLE
Add GitHub Flavored Markdown (GFM) features

### DIFF
--- a/flags.c
+++ b/flags.c
@@ -29,6 +29,8 @@ static struct flagnames flagnames[] = {
     { MKD_NOALPHALIST,    "!ALPHALIST" },
     { MKD_NODLIST,        "!DLIST" },
     { MKD_EXTRA_FOOTNOTE, "FOOTNOTE" },
+    { MKD_GITHUB_NEWLINES,"NEWLINES" },
+    { MKD_GITHUB_SYNTAX,  "SYNTAX" },	
 };
 #define NR(x)	(sizeof x/sizeof x[0])
 

--- a/generate.c
+++ b/generate.c
@@ -1558,9 +1558,14 @@ printblock(Paragraph *pp, MMIOT *f)
 	    else {
 		___mkd_tidy(&t->text);
 		push(T(t->text), S(t->text), f);
-		if ( t->next )
-		    push("\n", 1, f);
-	    }
+		if ( t->next ) {
+			if (f->flags & MKD_GITHUB_NEWLINES) {
+				push("\003\n", 2, f);
+			} else {
+				push("\n", 1, f);
+			}
+		}
+		}
 	}
 	t = t->next;
     }
@@ -1572,11 +1577,13 @@ printblock(Paragraph *pp, MMIOT *f)
 
 
 static void
-printcode(Line *t, MMIOT *f)
+printcode(Paragraph *p, MMIOT *f)
 {
     int blanks;
-
-    Qstring("<pre><code>", f);
+    Line *t = p->text;
+	
+    Qstring("<pre>", f);
+    Qprintf(f, p->ident ? "<%s %s>" : "<%s>", "code", p->ident);
     for ( blanks = 0; t ; t = t->next ) {
 	if ( S(t->text) > t->dle ) {
 	    while ( blanks ) {
@@ -1689,7 +1696,7 @@ display(Paragraph *p, MMIOT *f)
 	break;
 	
     case CODE:
-	printcode(p->text, f);
+	printcode(p, f);
 	break;
 	
     case QUOTE:

--- a/markdown.h
+++ b/markdown.h
@@ -33,7 +33,8 @@ typedef struct line {
 
     enum { chk_text, chk_code,
 	   chk_hr, chk_dash,
-	   chk_tilde, chk_equal } kind;
+	   chk_tilde, chk_equal,
+	   chk_backtick } kind;
     int count;
 } Line;
 
@@ -120,6 +121,8 @@ typedef struct mmiot {
 #define MKD_NOALPHALIST	0x00080000
 #define MKD_NODLIST	0x00100000
 #define MKD_EXTRA_FOOTNOTE 0x00200000
+#define MKD_GITHUB_NEWLINES 0x00400000
+#define MKD_GITHUB_SYNTAX 0x00800000
 #define IS_LABEL	0x08000000
 #define USER_FLAGS	0x0FFFFFFF
 #define INPUT_MASK	(MKD_NOHEADER|MKD_TABSTOP)

--- a/mkdio.h.in
+++ b/mkdio.h.in
@@ -100,6 +100,8 @@ void mkd_ref_prefix(MMIOT*, char*);
 #define MKD_NOALPHALIST	0x00080000	/* forbid alphabetic lists */
 #define MKD_NODLIST	0x00100000	/* forbid definition lists */
 #define MKD_EXTRA_FOOTNOTE 0x00200000	/* enable markdown extra-style footnotes */
+#define MKD_GITHUB_NEWLINES 0x00400000  /* enable github-style newlines */
+#define MKD_GITHUB_SYNTAX 0x00800000	/* enable github-style codefences & language identifier */
 #define MKD_EMBED	MKD_NOLINKS|MKD_NOIMAGE|MKD_TAGTEXT
 
 /* special flags for mkd_in() and mkd_string()

--- a/pgm_options.c
+++ b/pgm_options.c
@@ -54,6 +54,8 @@ static struct _opt {
     { "1.0",           "markdown 1.0 compatibility", 0, 0, 1, MKD_1_COMPAT },
     { "footnotes",     "markdown extra footnotes",   0, 0, 1, MKD_EXTRA_FOOTNOTE },
     { "footnote",      "markdown extra footnotes",   0, 1, 1, MKD_EXTRA_FOOTNOTE },
+    { "newlines",      "github-style newlines",   	 0, 0, 1, MKD_GITHUB_NEWLINES },
+    { "ghsyntax",      "github-style fences/syntax", 0, 0, 1, MKD_GITHUB_SYNTAX },
 } ;
 
 #define NR(x)	(sizeof x / sizeof x[0])


### PR DESCRIPTION
These changes add support for a couple of GFM features:
1. Treat newlines as real line breaks (code from issue #16).
2. Backtick code fences (```) with optional language identifier for syntax highlighting.

Reference: http://github.github.com/github-flavored-markdown/

I implemented these as runtime options, but later noticed in another issue that you aren't keen on adding anything else to the existing 32-bit flag word. If you're interested in pulling them in but would prefer another approach to enabling/disabling them, I'd be happy to make the necessary changes.
