### PR TITLE
Automatic anchor generation for headers.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -31,5 +31,6 @@ Ignacio Burgue?o--  bug reports about `>%class%`
 Henrik Nyh	--  bug reports about embedded html handling.
 John J. Foerch  --  bug reports about incorrect `&ndash;` and `&mdash;`
                     translations.
+Terry Golubiewski -- Automatic local link generation for headers.
 
 		    

--- a/generate.c
+++ b/generate.c
@@ -676,6 +676,33 @@ linkyformat(MMIOT *f, Cstring text, int image, Footnote *ref)
     return 1;
 } /* linkyformat */
 
+static int AutoAnchorHeaders = 1;
+
+static Cstring linky_local_url(const Cstring* str) {
+  Cstring result;
+  CREATE(result);
+  if (!str || !T(*str) || !S(*str))
+    return result;
+  RESERVE(result, S(*str) + 3);
+  if (!ALLOCATED(result))
+    return result;
+  const char* src = T(*str);
+  const char* const end = src + S(*str);
+  char* dst = T(result);
+  *dst = '#';
+  if (!isalpha(*src))
+    *++dst = 'L';
+  while (src != end) {
+    char c = *src++;
+    if (!c)
+      break;
+    int legal = (isalnum(c) || c == '_' || c == ':' || c == '-');
+    *++dst = legal ? c : '.';
+  }
+  *++dst = '\0';
+  S(result) = dst - T(result);
+  return result;
+}
 
 /*
  * process embedded links and images
@@ -734,6 +761,20 @@ linkylinky(int image, MMIOT *f)
 		    else
 			status = linkyformat(f, name, image, ref);
 		}
+                else if (AutoAnchorHeaders) {
+                    // If implicit link is not found assume it's a local header.
+                    Cstring url;
+                    url = linky_local_url(&name);
+                    if (ALLOCATED(url)) {
+                      Qstring("<a href=\"", f);
+                      Qwrite(T(url), S(url), f);
+                      Qstring("\">", f);
+                      Qwrite(T(name), S(name), f);
+                      Qstring("</a>", f);
+                      status = 1;
+                      DELETE(url);
+                    }
+                }
 	    }
 	}
     }
@@ -1398,7 +1439,7 @@ printheader(Paragraph *pp, MMIOT *f)
 {
 #if WITH_ID_ANCHOR
     Qprintf(f, "<h%d", pp->hnumber);
-    if ( f->flags & MKD_TOC ) {
+    if (AutoAnchorHeaders || (f->flags & MKD_TOC) ) {
 	Qstring(" id=\"", f);
 	mkd_string_to_anchor(T(pp->text->text),
 			     S(pp->text->text),
@@ -1407,7 +1448,7 @@ printheader(Paragraph *pp, MMIOT *f)
     }
     Qchar('>', f);
 #else
-    if ( f->flags & MKD_TOC ) {
+    if (AutoAnchorHeaders || (f->flags & MKD_TOC) ) {
 	Qstring("<a name=\"", f);
 	mkd_string_to_anchor(T(pp->text->text),
 			     S(pp->text->text),


### PR DESCRIPTION
Headers automatically generate anchors just like they do for automatic
table-of-contents generation. In addition, if an implicit link is not
explicitly defined anywhere, then an automatically generated header
anchor is assumed.

The only method of enabling/disabling this option is via a static global
variable, `AutoAnchorHeaders`, defined in generate.c.
