### PR TITLE
Added table captions ala Pandoc.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -31,5 +31,6 @@ Ignacio Burgue?o--  bug reports about `>%class%`
 Henrik Nyh	--  bug reports about embedded html handling.
 John J. Foerch  --  bug reports about incorrect `&ndash;` and `&mdash;`
                     translations.
+Terry Golubiewski -- Table captions.
 
 		    

--- a/dumptree.c
+++ b/dumptree.c
@@ -32,6 +32,7 @@ Pptype(int typ)
     case HDR       : return "header";
     case HR        : return "hr";
     case TABLE     : return "table";
+    case CAPTION   : return "caption";
     case SOURCE    : return "source";
     case STYLE     : return "style";
     default        : return "mystery node!";

--- a/generate.c
+++ b/generate.c
@@ -23,6 +23,8 @@ typedef void (*spanhandler)(MMIOT*,int);
 /* forward declarations */
 static void text(MMIOT *f);
 static Paragraph *display(Paragraph*, MMIOT*);
+static int printblock(Paragraph *pp, MMIOT *f);
+
 
 /* externals from markdown.c */
 int __mkd_footsort(Footnote *, Footnote *);
@@ -1472,7 +1474,7 @@ splat(Line *p, char *block, Istring align, int force, MMIOT *f)
 
 
 static int
-printtable(Paragraph *pp, MMIOT *f)
+printtable(Paragraph *pp, Paragraph *caption, MMIOT *f)
 {
     /* header, dashes, then lines of content */
 
@@ -1519,6 +1521,13 @@ printtable(Paragraph *pp, MMIOT *f)
     }
 
     Qstring("<table>\n", f);
+    if (caption) {
+        if (caption->align == PARA)
+            caption->align = IMPLICIT;
+        Qstring("<caption>\n", f);
+        printblock(caption, f);
+        Qstring("\n</caption>\n", f);
+    }
     Qstring("<thead>\n", f);
     hcols = splat(hdr, "th", align, 0, f);
     Qstring("</thead>\n", f);
@@ -1714,8 +1723,21 @@ display(Paragraph *p, MMIOT *f)
 	printheader(p, f);
 	break;
 
+    case CAPTION:
+        if (p->next && p->next->typ == TABLE) {
+            printtable(p->next, p, f);
+            p = p->next;
+        }
+        break;
+
     case TABLE:
-	printtable(p, f);
+        if (p->next && p->next->typ == CAPTION) {
+            printtable(p, p->next, f);
+            p = p->next;
+        }
+        else {
+            printtable(p, 0, f);
+        }
 	break;
 
     case SOURCE:

--- a/markdown.c
+++ b/markdown.c
@@ -402,6 +402,22 @@ ishdr(Line *t, int *htyp)
     return issetext(t, htyp);
 }
 
+static int
+iscaption(Line* t, int *htyp)
+{
+  /* A caption is a paragraph that starts with, optionally "Table"
+   * followed by, a colon.
+   */
+  if (t->dle != 0 || S(t->text) <= 1)
+   return 0;
+  int i = 0;
+  if (!strncasecmp(T(t->text), "Table", 5))
+    i = nextnonblank(t, 5);
+  if (T(t->text)[i] != ':')
+    return 0;
+  *htyp = CAPTION;
+  return 1;
+}
 
 static inline int
 end_of_block(Line *t)
@@ -688,6 +704,22 @@ textblock(Paragraph *p, int toplevel, DWORD flags)
 	}
     }
     return t;
+}
+
+
+static Line *
+captionblock(Paragraph *pp, int toplevel, DWORD flags)
+{
+    Line *p = pp->text;
+    int i;
+
+    for (i = p->dle; T(p->text)[i] != ':'; ++i)
+      ;
+    i = nextnonblank(p, i+1);
+    CLIP(p->text, 0, i);
+    UNCHECK(p);
+
+    return textblock(pp, toplevel, flags);
 }
 
 
@@ -1241,6 +1273,10 @@ compile(Line *ptr, int toplevel, MMIOT *f)
 	    p = Pp(&d, ptr, HDR);
 	    ptr = headerblock(p, hdr_type);
 	}
+        else if ( iscaption(ptr, &hdr_type) ) {
+            p = Pp(&d, ptr, CAPTION);
+            ptr = captionblock(p, toplevel, f->flags);
+        }
 	else {
 	    p = Pp(&d, ptr, MARKUP);
 	    ptr = textblock(p, toplevel, f->flags);

--- a/markdown.h
+++ b/markdown.h
@@ -49,7 +49,7 @@ typedef struct paragraph {
     char *ident;		/* %id% tag for QUOTE */
     enum { WHITESPACE=0, CODE, QUOTE, MARKUP,
 	   HTML, STYLE, DL, UL, OL, AL, LISTITEM,
-	   HDR, HR, TABLE, SOURCE } typ;
+	   HDR, HR, TABLE, CAPTION, SOURCE } typ;
     enum { IMPLICIT=0, PARA, CENTER} align;
     int hnumber;		/* <Hn> for typ == HDR */
 } Paragraph;


### PR DESCRIPTION
A table caption is a paragraph that either preceeds or follows a table
that begins with either just a colon ":" or "Table:".
