### PR TITLE
MKD_NOSTYLE disables special <style> processing.

### DIFF
--- a/main.c
+++ b/main.c
@@ -64,7 +64,7 @@ main(int argc, char **argv)
 {
     int opt;
     int rc;
-    mkd_flag_t flags = 0;
+    mkd_flag_t flags = MKD_NOSTYLE;
     int debug = 0;
     int toc = 0;
     int version = 0;


### PR DESCRIPTION
The markdown command should not do any special <style> processing.
Therefore, main.c sets the flags to MKD_NOSTYLE by default. Setting the
flags via the MARKDOWN_FLAGS or using the -F option will cause <styles>
to be filtered out if MKD_NOSTYLE is not set.
