### PR TITLE
Update mkdio.c

### DIFF
--- a/mkdio.c
+++ b/mkdio.c
@@ -102,7 +102,8 @@ populate(getc_func getc, void* ctx, int flags)
     CREATE(line);
 
     while ( (c = (*getc)(ctx)) != EOF ) {
-	if ( c == '\n' ) {
+    	// Mou - add support for windows line breaks
+	if ( c == '\n' || c == '\r' ) {
 	    if ( pandoc != EOF && pandoc < 3 ) {
 		if ( S(line) && (T(line)[0] == '%') )
 		    pandoc++;


### PR DESCRIPTION
Add support for windows line breaks. It's needed as some users need to open the old Markdown files which are originally created on Windows.
