### PR TITLE
Support Markdown-formatted text inside HTML blocks

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -1695,7 +1695,11 @@ display(Paragraph *p, MMIOT *f)
 	break;
 
     case HTML:
-	printhtml(p->text, f);
+	if (p->text)
+	    printhtml(p->text, f);
+	else
+	    htmlify(p->down, 0, 0, f);
+
 	break;
 	
     case CODE:

--- a/mkd-extensions.7
+++ b/mkd-extensions.7
@@ -190,6 +190,39 @@ footnotes are supported.   If a footnote link begins with a
 the first use of that footnote will generate a link down to the 
 bottom of the rendered document, which will contain a numbered footnote
 with a link back to where the footnote was called.
+.Ss markdown inside HTML blocks
+By default HTML block elements like
+.Em <div>
+elements couldn't wrap Markdown-formatted content. This can
+be changed by adding an attribute of the name
+.Em markdown
+and the value
+.Em "span"
+, respectively
+.Em "1"
+to the element:
+.nf
+
+	<div markdown="1">This _is_ awesome!</div>
+
+.fi
+An emty SGML also enables Markdown processing:
+.nf
+
+	<div markdown>This _much_ more convenient.</div>
+
+.fi
+To disable pass a value of
+.Em "block"
+or
+.Em "0"
+
+This feature follows the behavior of
+.Ar PHP Markdown Extra
+but isn't complete: It is not possible to disable Markdown processing for
+span elements yet. Also nested block elements don't inherit the
+.Em markdown
+attribute of their anchestors.
 .Sh AUTHOR
 David Parsons
 .%T http://www.pell.portland.or.us/~orc/

--- a/tests/html.t
+++ b/tests/html.t
@@ -128,5 +128,15 @@ try 'comment, no white space' '<!--foo-->' '<!--foo-->'
 
 try 'unclosed block' '<p>here we go!' '<p><p>here we go!</p>'
 
+try 'div with markdown' '<div markdown>*test*</div>' '<div><em>test</em></div>'
+try 'div with markdown and attribute before' '<div class=test markdown>*test*</div>' '<div class=test><em>test</em></div>'
+try 'div with markdown and attribute after' '<div markdown class=test>*test*</div>' '<div class=test><em>test</em></div>'
+try 'div with markdown=0' '<div markdown=0>*test*</div>' '<div>*test*</div>'
+try 'div with markdown=1' '<div markdown=1 class=test>*test*</div>' '<div class=test><em>test</em></div>'
+try 'div with markdown="0"' '<div markdown="0">*test*</div>' '<div>*test*</div>'
+try 'div with markdown="1"' '<div markdown="1" class="test">*test*</div>' '<div class="test"><em>test</em></div>'
+try "div with markdown='block'" "<div markdown='block'>*test*</div>" '<div>*test*</div>'
+try "div with markdown='span'" "<div markdown='span' class='test'>*test*</div>" "<div class='test'><em>test</em></div>"
+
 summary $0
 exit $rc


### PR DESCRIPTION
Previously `<div>` elements couldn’t wrap Markdown-formatted content inside. This is because `<div>` is a block element and plain Markdown does not format the content of such.

With this change the behavior for HTML block elements is configurable now. To enable Markdown processing add a "markdown" attribute with a value of `1` or `span` to the element. An empty SGML attribute, as in `<div markdown>` also enables Markdown processing. To disable pass a value of `0` or `block`.

This feature was introduced by PHP Markdown Extra.

Limitations:
- In contrast to PHP Markdown Extra this doesn't permit to disable Markdown processing for inline elements yet.
- The value of this attribute is not inherited by child elements yet.
