### PR TITLE
Fix potential leak found by cppcheck

### DIFF
--- a/theme.c
+++ b/theme.c
@@ -85,16 +85,22 @@ typedef char* HERE;
 HERE
 pushd(char *d)
 {
-    HERE cwd;
+    HERE cwd, cwd2;
     int size;
     
     if ( chdir(d) == -1 )
 	return NOT_HERE;
 
-    for (cwd = malloc(size=40); cwd; cwd = realloc(cwd, size *= 2))
+    if ( !(cwd = malloc(size=40)) )
+	return NOT_HERE;
+
+    while ( cwd2 = realloc(cwd, size *= 2) ) {
+	cwd = cwd2;
 	if ( getcwd(cwd, size) )
 	    return cwd;
+    }
 
+    free(cwd);
     return NOT_HERE;
 }
 


### PR DESCRIPTION
If realloc returns NULL, the original memory is untouched, and if not
otherwise needed, must be freed manually.

This pull request fixes this potential problem in theme.c
