### PR TITLE
Fix support for “$ CFLAGS=-m32 ./configure.sh” by using CFLAGS for all build invokations of CC.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -64,7 +64,7 @@ $(DESTDIR)$(LIBDIR):
 	@INSTALL_DIR@ $(DESTDIR)$(LIBDIR)
 
 version.o: version.c VERSION
-	$(CC) -DVERSION=\"`cat VERSION`\" -c version.c
+	$(CC) $(CFLAGS) -DVERSION=\"`cat VERSION`\" -c version.c
 
 VERSION:
 	@true
@@ -76,23 +76,23 @@ blocktags: mktags
 
 # example programs
 @THEME@theme:  theme.o $(MKDLIB) mkdio.h
-@THEME@	$(CC) $(LFLAGS) -o theme theme.o pgm_options.o -lmarkdown @LIBS@
+@THEME@	$(CC) $(CFLAGS) $(LFLAGS) -o theme theme.o pgm_options.o -lmarkdown @LIBS@
 
 
 mkd2html:  mkd2html.o $(MKDLIB) mkdio.h
-	$(CC) $(LFLAGS) -o mkd2html mkd2html.o -lmarkdown @LIBS@
+	$(CC) $(CFLAGS) $(LFLAGS) -o mkd2html mkd2html.o -lmarkdown @LIBS@
 
 markdown: main.o pgm_options.o $(MKDLIB)
-	$(CC) $(LFLAGS) -o markdown main.o pgm_options.o -lmarkdown @LIBS@
+	$(CC) $(CFLAGS) $(LFLAGS) -o markdown main.o pgm_options.o -lmarkdown @LIBS@
 	
 makepage:  makepage.c pgm_options.o $(MKDLIB) mkdio.h
-	$(CC) $(LFLAGS) -o makepage makepage.c pgm_options.o -lmarkdown @LIBS@
+	$(CC) $(CFLAGS) $(LFLAGS) -o makepage makepage.c pgm_options.o -lmarkdown @LIBS@
 
 pgm_options.o: pgm_options.c mkdio.h config.h
-	$(CC) -I. -c pgm_options.c
+	$(CC) $(CFLAGS) -I. -c pgm_options.c
 
 main.o: main.c mkdio.h config.h
-	$(CC) -I. -c main.c
+	$(CC) $(CFLAGS) -I. -c main.c
 
 $(MKDLIB): $(OBJS)
 	./librarian.sh make $(MKDLIB) VERSION $(OBJS)


### PR DESCRIPTION
Without this changeset:

```
cc -Wno-return-type -Wno-implicit-int -I. -L. -o markdown main.o pgm_options.o -lmarkdown 
cc -Wno-return-type -Wno-implicit-int -I. -L. -o mkd2html mkd2html.o -lmarkdown 
cc -Wno-return-type -Wno-implicit-int -I. -L. -o makepage makepage.c pgm_options.o -lmarkdown 
cc -Wno-return-type -Wno-implicit-int -I. -L. -o theme theme.o pgm_options.o -lmarkdown 
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible ./libmarkdown.a when searching for -lmarkdown
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmarkdown
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible ./libmarkdown.a when searching for -lmarkdown
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmarkdown
collect2: ld returned 1 exit status
collect2: ld returned 1 exit status
make: *** [markdown] Error 1
make: *** Waiting for unfinished jobs....
make: *** [theme] Error 1
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible ./libmarkdown.a when searching for -lmarkdown
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmarkdown
collect2: ld returned 1 exit status
make: *** [mkd2html] Error 1
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible ./libmarkdown.a when searching for -lmarkdown
/usr/lib/gcc/x86_64-pc-linux-gnu/4.6.3/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lmarkdown
collect2: ld returned 1 exit status
make: *** [makepage] Error 1
```

with:

```
cc -Wno-return-type -Wno-implicit-int -I. -m32 -L. -o markdown main.o pgm_options.o -lmarkdown 
cc -Wno-return-type -Wno-implicit-int -I. -m32 -L. -o mkd2html mkd2html.o -lmarkdown 
cc -Wno-return-type -Wno-implicit-int -I. -m32 -L. -o makepage makepage.c pgm_options.o -lmarkdown 
cc -Wno-return-type -Wno-implicit-int -I. -m32 -L. -o theme theme.o pgm_options.o -lmarkdown 
```

(no errors).
