### PR TITLE
check to see if S(extratags) before EXPAND(extratags)

### DIFF
--- a/tags.c
+++ b/tags.c
@@ -26,6 +26,9 @@ mkd_define_tag(char *id, int selfclose)
      * either the standard or extra tag tables.
      */
     if ( !(p = mkd_search_tags(id, strlen(id))) ) {
+	/* extratags could be deallocated */
+	if ( S(extratags) == 0 )
+	    CREATE(extratags);
 	p = &EXPAND(extratags);
 	p->id = id;
 	p->size = strlen(id);


### PR DESCRIPTION
if you call mkd_define_tag() after mkd_deallocate_tags(), it causes an error. Here is the fix to call CREATE(extratags) in case extratags is deallocated already.
