### PR TITLE
no way to reset static int variable "populated" in mkd_with_html5_tags()

### DIFF
--- a/html5.c
+++ b/html5.c
@@ -3,11 +3,11 @@
 #include "tags.h"
 
 void
-mkd_with_html5_tags()
+mkd_with_html5_tags(int force_populate)
 {
     static int populated = 0;
 
-    if ( populated ) return;
+    if ( populated && !force_populate ) return;
     populated = 1;
 
     mkd_define_tag("ASIDE", 0);


### PR DESCRIPTION
If you call mkd_with_html5_tags() and mkd_deallocate_tags(), calling mkd_with_html5_tags() won't define html5 tags anymore because of a static int variable "populated" in mkd_with_html5_tags(). There could be two ways 1) adding an option to force defining tags (my change does this) or 2) reset "populated" in mkd_deallocate_tags(), which I did not come up with a nice code to do it.
