### PR TITLE
Multi-line footnotes

### DIFF
--- a/markdown.c
+++ b/markdown.c
@@ -1017,12 +1017,25 @@ addfootnote(Line *p, MMIOT* f)
     S(foot->tag)--;
     j = nextnonblank(p, j+2);
 
+    /* Expand ^1-style footnotes */
+    /* Handles multi-line, but does not handle embedded block elements */
     if ( (f->flags & MKD_EXTRA_FOOTNOTE) && (T(foot->tag)[0] == '^') ) {
-	while ( j < S(p->text) )
-	    EXPAND(foot->title) = T(p->text)[j++];
-	goto skip_to_end;
+        while (1) {
+            while ( j < S(p->text) )
+                EXPAND(foot->title) = T(p->text)[j++];
+
+            if (blankline(np))
+                break;
+
+            EXPAND(foot->title) = '\n';
+            p = np;
+            np = p->next;
+            j = nextnonblank(p, 0);
+        }
+        goto skip_to_end;
     }
 
+    /* Expand implicit references */
     while ( (j < S(p->text)) && !isspace(T(p->text)[j]) )
 	EXPAND(foot->link) = T(p->text)[j++];
     EXPAND(foot->link) = 0;

--- a/tests/extrafootnotes.t
+++ b/tests/extrafootnotes.t
@@ -6,6 +6,7 @@ rc=0
 MARKDOWN_FLAGS=
 
 FOOTIE='I haz a footnote[^1]
+
 [^1]: yes?'
 
 try -ffootnote 'footnotes (-ffootnote)' "$FOOTIE" \
@@ -18,16 +19,52 @@ try -ffootnote 'footnotes (-ffootnote)' "$FOOTIE" \
 </ol>
 </div>'
 
-try -ffootnote 'footnotes (-ffootnote)' "$FOOTIE
-    second" \
+try -ffootnote 'Simple, multi-line footnote' 'I haz a footnote[^1]
+
+[^1]: yes?
+really.' \
 '<p>I haz a footnote<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup></p>
 <div class="footnotes">
 <hr/>
 <ol>
 <li id="fn:1">
-<p>yes?</p><p>second<a href="#fnref:1" rev="footnote">&#8617;</a></p></li>
+<p>yes?
+really.<a href="#fnref:1" rev="footnote">&#8617;</a></p></li>
 </ol>
 </div>'
+
+try -ffootnote 'Indented, multi-line footnote' 'I haz a footnote[^1]
+
+[^1]: yes?
+      really.' \
+'<p>I haz a footnote<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup></p>
+<div class="footnotes">
+<hr/>
+<ol>
+<li id="fn:1">
+<p>yes?
+really.<a href="#fnref:1" rev="footnote">&#8617;</a></p></li>
+</ol>
+</div>'
+
+try -ffootnote 'Multi-line footnote followed by paragraph' 'I haz a footnote[^1]
+
+[^1]: yes?
+      really.
+
+Another paragraph' \
+'<p>I haz a footnote<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup></p>
+
+<p>Another paragraph</p>
+<div class="footnotes">
+<hr/>
+<ol>
+<li id="fn:1">
+<p>yes?
+really.<a href="#fnref:1" rev="footnote">&#8617;</a></p></li>
+</ol>
+</div>'
+
 
 try -ffootnote -Cfoot 'footnotes (-ffootnote -Cfoot)' "$FOOTIE" \
 '<p>I haz a footnote<sup id="footref:1"><a href="#foot:1" rel="footnote">1</a></sup></p>

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -27,6 +27,7 @@ summary() {
 }
 
 
+# try -flags... 'Title' '...input-markdown...' '...expected-html...'
 try() {
     unset FLAGS
     while [ "$1" ]; do


### PR DESCRIPTION
Handles footnotes with hard-breaks in them according to PHP-Markdown's spec. Doesn't handle full multi-paragraph footnotes (#98).

Adds additional tests, and makes existing tests more closely match [PHP-Markdown's tests](https://github.com/michelf/mdtest/blob/master/PHP%20Markdown%20Extra.mdtest/Footnotes.text). There is still substantial work needed to bring this in line with PHP-Markdown.
