### PR TITLE
Adjust theme to allow output to stdout (-o /dev/stdout)

### DIFF
--- a/theme.c
+++ b/theme.c
@@ -499,6 +499,18 @@ spin(FILE *template, MMIOT *doc, FILE *output)
     }
 } /* spin */
 
+/* isstdout() - returns true iff path is the same file as stdout
+*/
+static int
+isstdout(const char *path)
+{
+    struct stat pathstat, stdoutstat;
+
+    return
+	!stat(path, &pathstat) && !fstat(STDOUT_FILENO, &stdoutstat)
+	&& pathstat.st_ino == stdoutstat.st_ino
+	&& pathstat.st_dev == stdoutstat.st_dev;
+}
 
 main(argc, argv)
 char **argv;
@@ -592,7 +604,7 @@ char **argv;
 	    strcat(q, ".html");
 	}
     }
-    if ( output ) {
+    if ( output && !isstdout(output) ) {
 	if ( force )
 	    unlink(output);
 	if ( !freopen(output, "w", stdout) )


### PR DESCRIPTION
When the `theme` command is given the output option `-o /dev/stdout`, an error is raised because freopen() can't reopen stdout again. This pull-request fixes the issue by testing the output path for inode-identity before re-opening. A less complex alternative would be to adopt the dash convention `-o -` to signify standard output.

Having `theme` output to standard-out is particularly useful for simple CGI scripts. For example, with the fix, the following CGI script can be used to serve rendered markdown files. Without the fix, a temporary file must be created (and deleted) to capture the output.

```
#!/bin/sh                                                                       
echo "Content-type: text/html"
echo
cd $(dirname "$PATH_TRANSLATED")
theme -o /dev/stdout "$PATH_TRANSLATED"
```
