### PR TITLE
Mangle email addresses deterministically

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -107,14 +107,6 @@ else
     AC_FAIL "$TARGET requires bzero or memset"
 fi
 
-if AC_CHECK_FUNCS random; then
-    AC_DEFINE 'COINTOSS()' '(random()&1)'
-elif AC_CHECK_FUNCS rand; then
-    AC_DEFINE 'COINTOSS()' '(rand()&1)'
-else
-    AC_DEFINE 'COINTOSS()' '1'
-fi
-
 if AC_CHECK_FUNCS strcasecmp; then
     :
 elif AC_CHECK_FUNCS stricmp; then

--- a/generate.c
+++ b/generate.c
@@ -785,7 +785,7 @@ mangle(char *s, int len, MMIOT *f)
 {
     while ( len-- > 0 ) {
 	Qstring("&#", f);
-	Qprintf(f, COINTOSS() ? "x%02x;" : "%02d;", *((unsigned char*)(s++)) );
+	Qprintf(f, (len % 2 == 0) ? "x%02x;" : "%02d;", *((unsigned char*)(s++)) );
     }
 }
 


### PR DESCRIPTION
Hi,

I'm working on the [Reproducible Builds][1] project in Debian, which is trying to make it possible to rebuild every package in Debian reproducibly.  Once complete, reproducible builds will let users independently verify that a binary package corresponds to its purported source and hasn't been surreptitiously modified.

Some of our packages use discount to generate their documentation, and we've noticed that discount currently [mangles email addresses in a random manner][2].  This causes different builds of the same package to be different.  We assume that the current behavior of randomly choosing between hex and decimal encoding is intended to defeat email scrapers that understand one encoding but not the other.  Could discount instead alternate every other character between hex and decimal? This would accomplish the same effect but in a deterministic manner.

The following patch changes the `mangle` function accordingly.  Could it be applied to discount?

Thanks!
Andrew

[1]: https://wiki.debian.org/ReproducibleBuilds
[2]: https://github.com/Orc/discount/blob/4de75a3026ae47bde4b53fce71d486a42cce82aa/generate.c#L788
