### PR TITLE
Fix build with MSYS2: require --use-windows-headers before including win...

### DIFF
--- a/configure.inc
+++ b/configure.inc
@@ -871,15 +871,7 @@ AC_SCALAR_TYPES () {
 
     rc=1
     LOGN "defining WORD & DWORD scalar types"
-    
-    if AC_QUIET AC_CHECK_HEADERS WinDef.h; then
-	# windows machine; BYTE, WORD, DWORD already
-	# defined
-	echo "#include <WinDef.h>" >> $__cwd/config.h
-	TLOG " (defined in WinDef.h)"
-	return 0
-    fi
-	
+
     cat > ngc$$.c << EOF
 #include <stdio.h>
 #include <string.h>

--- a/configure.sh
+++ b/configure.sh
@@ -8,6 +8,7 @@
 # load in the configuration file
 #
 ac_help='--enable-amalloc	Enable memory allocation debugging
+--use-windows-headers	Use Windows headers for DWORD
 --with-tabstops=N	Set tabstops to N characters (default is 4)
 --with-dl=X		Use Discount, Extra, or Both types of definition list
 --with-id-anchor	Use id= anchors for table-of-contents links
@@ -40,6 +41,9 @@ locals() {
     --DEBIAN-GLITCH)
 		echo DEBIAN_GLITCH=T
 		;;
+    --USE-WINDOWS-HEADERS)
+        echo USE_WINDOWS_HEADERS=T
+        ;;
     esac
 }
 
@@ -90,7 +94,22 @@ AC_PROG ranlib
 AC_C_VOLATILE
 AC_C_CONST
 AC_C_INLINE
-AC_SCALAR_TYPES sub hdr
+LOGN "Checking if we should use Windows typedefs"
+if test "$USE_WINDOWS_HEADERS" && AC_QUIET AC_CHECK_HEADERS WinDef.h; then
+	# windows machine; BYTE, WORD, DWORD already
+	# defined
+	echo "#define WIN32_LEAN_AND_MEAN" >> $__cwd/config.h
+    echo "#define NOMINMAX" >> $__cwd/config.h
+	echo "#include <WinDef.h>" >> $__cwd/config.h
+	TLOG " (defined in WinDef.h)"
+    # still want substitutions for mkdio.h to avoid including another header there
+    AC_SCALAR_TYPES sub
+	else
+	AC_SUB 'DWORD_INCLUDE' ''
+    TLOG " (no)"
+    AC_SCALAR_TYPES sub hdr
+fi
+
 AC_CHECK_BASENAME
 
 AC_CHECK_HEADERS sys/types.h pwd.h && AC_CHECK_FUNCS getpwuid


### PR DESCRIPTION
...def.h

Otherwise, you pull in a lot more than just typedefs for DWORD,
including conflicting DELETE macros, etc.

The recent change to use existing Windows definitions of DWORD, etc. might work fine for the RDiscount team with their toolchain, but when using a (pretty tame) MSYS2/MinGW64-i686 toolchain, that Windows header pulls in a lot of mess, and I ended up with enough warnings that I wasn't confident the resulting binaries would work as intended.

So, I've placed that behavior behind a configure flag (since the previous behavior worked for me).

I've also improved that alternate behavior by making sure that if we're using WinDef.h, we still have a substitution for `@DWORD@`. Rather than forcing a windows header into `mkdio.h` I opted to let the existing type detection compute the correct substitution, just not the definition, especially since the configure system seemed to be designed to make that possible/easy.
