### PR TITLE
Fix deterministic email address mangling

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -786,7 +786,7 @@ mangle(char *s, int len, MMIOT *f)
 {
     while ( len-- > 0 ) {
 #if DEBIAN_GLITCH
-	Qprintf(f, "&#02d;", *((unsigned char*)(s++)) );
+	Qprintf(f, "&#%02d;", *((unsigned char*)(s++)) );
 #else
 	Qstring("&#", f);
 	Qprintf(f, COINTOSS() ? "x%02x;" : "%02d;", *((unsigned char*)(s++)) );


### PR DESCRIPTION
The format string lacked a `%`.