### PR TITLE
Add debug symbols files to make clean.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -113,7 +113,7 @@ echo:   tools/echo.c config.h
 	$(CC) -o echo tools/echo.c
 	
 clean:
-	rm -f $(PGMS) $(TESTFRAMEWORK) $(SAMPLE_PGMS) *.o
+	rm -rf $(PGMS) $(TESTFRAMEWORK) $(SAMPLE_PGMS) *.o *.dSYM/
 	rm -f $(MKDLIB) `./librarian.sh files $(MKDLIB) VERSION`
 
 distclean spotless: clean


### PR DESCRIPTION
`make clean && make distclean` should now leave a spotless source directory.