### PR TITLE
handle cleanup from the caller

### DIFF
--- a/dumptree.c
+++ b/dumptree.c
@@ -145,7 +145,6 @@ mkd_dump(Document *doc, FILE *out, int flags, char *title)
 	dumptree(doc->code, &stack, out);
 	DELETE(stack);
 
-	mkd_cleanup(doc);
 	return 0;
     }
     return -1;

--- a/main.c
+++ b/main.c
@@ -206,9 +206,9 @@ main(int argc, char **argv)
 		    mkd_generatetoc(doc, stdout);
 		if ( content )
 		    mkd_generatehtml(doc, stdout);
-		mkd_cleanup(doc);
 	    }
 	}
+	mkd_cleanup(doc);
     }
     mkd_deallocate_tags();
     adump();

--- a/makepage.c
+++ b/makepage.c
@@ -30,6 +30,7 @@ char **argv;
     char *q;
     int version = 0;
     int opt;
+    int ret;
     mkd_flag_t flags = 0;
 
     if ( (q = getenv("MARKDOWN_FLAGS")) )
@@ -82,5 +83,9 @@ char **argv;
 	exit(1);
     }
 
-    exit(mkd_xhtmlpage(doc, flags, stdout));
+    ret = mkd_xhtmlpage(doc, flags, stdout);
+
+    mkd_cleanup(doc);
+
+    exit(ret);
 }

--- a/xmlpage.c
+++ b/xmlpage.c
@@ -39,8 +39,6 @@ mkd_xhtmlpage(Document *p, int flags, FILE *out)
 	mkd_generatehtml(p, out);
 	fprintf(out, "</body>\n");
 	fprintf(out, "</html>\n");
-	
-	mkd_cleanup(p);
 
 	return 0;
     }


### PR DESCRIPTION
I'll quote myself:

> I'm currently trying to reimplement the [php-discount extension](https://github.com/cataphract/php-discount), but instead of using the bundled library, I'm building it against the shared library: https://github.com/koenpunt/php-discount 

This commit moves the calls to `mkd_cleanup` from the called context to the caller context. 

This to prevent `EXC_BAD_ACCESS` errors when calling the method multiple times from outside of the library. 

See [here](https://github.com/koenpunt/php-discount/blob/master/markdowndoc_meth_misc.c#L103) and [here](https://github.com/koenpunt/php-discount/blob/master/tests/dump_tree_basic.phpt#L12-L13)