### PR TITLE
prevent appearance of <NUL> chars

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -1818,6 +1818,10 @@ mkd_document(Document *p, char **res)
 	    EXPAND(p->ctx->out) = 0;
 	
 	*res = T(p->ctx->out);
+
+	p->html = 0;
+	CREATE(p->ctx->out);
+
 	return size;
     }
     return EOF;


### PR DESCRIPTION
when `mkd_document` was called multiple times, a `<NUL>` char appeared.

This fix is also pulled from the original php-discount extension, but I'm not really sure what the implications of this change are. 

So this is a possible fix for #132