### PR TITLE
Fix a compilation error

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -1212,7 +1212,7 @@ smartypants(int c, int *flags, MMIOT *f)
  * delimiters
  */
 static int
-mathhandler(MMIOT *f, int e1, e2)
+mathhandler(MMIOT *f, int e1, int e2)
 {
     int i = 0;
 


### PR DESCRIPTION

```
cc -Wno-return-type -Wno-implicit-int -I. -fPIC -ggdb3 -O3   -c -o generate.o generate.c
generate.c:1215:31: error: unknown type name ‘e2’
 mathhandler(MMIOT *f, int e1, e2)
                               ^
In file included from generate.c:14:0:
generate.c: In function ‘text’:
generate.c:1415:24: warning: implicit declaration of function ‘mathhandler’ [-Wimplicit-function-declaration]
       case '(':   if ( mathhandler(f, '\\', (c =='(')?')':']') )
                        ^
config.h:12:20: note: in definition of macro ‘if’
 #define if(x) if( (x) != 0 )
                    ^
<builtin>: recipe for target 'generate.o' failed
make: *** [generate.o] Error 1
```