### PR TITLE
Added support of pkg-config

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,6 +8,7 @@ BINDIR=@exedir@
 MANDIR=@mandir@
 LIBDIR=@libdir@
 INCDIR=@prefix@/include
+PKGDIR=$(LIBDIR)/pkgconfig
 
 PGMS=markdown
 SAMPLE_PGMS=mkd2html makepage
@@ -23,10 +24,11 @@ MAN3PAGES=mkd-callbacks.3 mkd-functions.3 markdown.3 mkd-line.3
 
 all: $(PGMS) $(SAMPLE_PGMS) $(TESTFRAMEWORK)
 
-install: $(PGMS) $(DESTDIR)$(BINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCDIR)
+install: $(PGMS) $(DESTDIR)$(BINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCDIR) $(DESTDIR)$(PKGDIR)
 	@INSTALL_PROGRAM@ $(PGMS) $(DESTDIR)$(BINDIR)
 	./librarian.sh install libmarkdown VERSION $(DESTDIR)$(LIBDIR)
 	@INSTALL_DATA@ mkdio.h $(DESTDIR)$(INCDIR)
+	@INSTALL_DATA@ $(MKDLIB).pc $(DESTDIR)$(PKGDIR)
 
 install.everything: install install.samples install.man
 
@@ -64,6 +66,9 @@ $(DESTDIR)$(INCDIR):
 
 $(DESTDIR)$(LIBDIR):
 	@INSTALL_DIR@ $(DESTDIR)$(LIBDIR)
+
+$(DESTDIR)$(PKGDIR): $(DESTDIR)$(LIBDIR)
+	@INSTALL_DIR@ $(DESTDIR)$(PKGDIR)
 
 version.o: version.c VERSION
 	$(CC) $(CFLAGS) -DVERSION=\"`cat VERSION`\" -c version.c

--- a/configure.sh
+++ b/configure.sh
@@ -34,10 +34,13 @@ locals() {
     esac
 }
 
+VERSION=`cat VERSION`
 TARGET=markdown
 . ./configure.inc
 
 AC_INIT $TARGET
+AC_SUB 'PACKAGE_NAME' lib$TARGET
+AC_SUB 'PACKAGE_VERSION' $VERSION
 
 for banned_with in dl fenced-code id-anchor github-tags urlencoded-anchor; do
     banned_with_variable_ref=\$WITH_`echo "$banned_with" | $AC_UPPERCASE | tr - _`
@@ -159,4 +162,4 @@ fi
 
 [ "$WITH_PANDOC_HEADER" ] && AC_DEFINE 'PANDOC_HEADER' '1'
 
-AC_OUTPUT Makefile version.c mkdio.h
+AC_OUTPUT Makefile version.c mkdio.h libmarkdown.pc

--- a/libmarkdown.pc.in
+++ b/libmarkdown.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=@libdir@
+includedir=@prefix@/include
+
+Name: @PACKAGE_NAME@
+Version: @PACKAGE_VERSION@
+Description: C implementation of John Gruber's Markdown markup language
+
+Libs: -L${libdir} -lmarkdown @LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
Have implemented support for pkg-config

Using this library in Swift ([Markdown](https://github.com/crossroadlabs/Markdown)) and `pkg-config` is the only proper way (at least for now) to import system libraries to Swift Package Manager.

Anyways, it will do no harm ;)