### PR TITLE
mkd2html: print <title> even when no title is available

### DIFF
--- a/mkd2html.c
+++ b/mkd2html.c
@@ -170,6 +170,8 @@ char **argv;
 	fprintf(output,"  <title>");
 	mkd_generateline(h, strlen(h), output, 0);
 	fprintf(output, "</title>\n");
+    }else {
+	fprintf(output, "  <title></title>\n");
     }
     for ( i=0; i < S(headers); i++ )
 	fprintf(output, "  %s\n", T(headers)[i]);


### PR DESCRIPTION
According to the W3C HTML(4) specification:

```
Every HTML document **must** have a TITLE element in the HEAD section.
```

So add an empty one when we have no title available.

Refer-to: The global structure of an HTML document
<https://www.w3.org/TR/html401/struct/global.html#h-7.4.2>
Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>

This is really a make-the-validator-happy kind of patch, with no practical usage, probably shouldn't be pulled