### PR TITLE
Define strncasecmp as _strnicmp for Visual C++

### DIFF
--- a/mktags.c
+++ b/mktags.c
@@ -2,6 +2,13 @@
  */
 #include <stdio.h>
 
+#ifdef _MSC_VER
+#ifndef strncasecmp
+#include <string.h>
+#define strncasecmp _strnicmp
+#endif
+#endif
+
 #define __WITHOUT_AMALLOC 1
 #include "cstring.h"
 #include "tags.h"


### PR DESCRIPTION
Simple fix to enable compilation with Visual C++