### PR TITLE
Remove redundant <unistd.h> header as unused

### DIFF
--- a/pgm_options.c
+++ b/pgm_options.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <unistd.h>
 #include <mkdio.h>
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
This also enables compilation of  `pgm_options.c` with VC++