### PR TITLE
Add Makefile for NMAKE and Visual C++ toolset

### DIFF
--- a/msvc/Makefile
+++ b/msvc/Makefile
@@ -1,0 +1,57 @@
+# NMAKE Makefile to build Discount with Visual C++
+CFLAGS	=	/nologo /MP /MDd /EHa /Zi \
+			/D_CRT_SECURE_NO_DEPRECATE /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS \
+			/I.
+LIBOBJ	=	mkdio.obj markdown.obj dumptree.obj generate.obj \
+			resource.obj docheader.obj version.obj toc.obj css.obj \
+			xml.obj Csio.obj xmlpage.obj basename.obj emmatch.obj \
+			github_flavoured.obj setup.obj tags.obj html5.obj flags.obj
+MKDLIB	= libmarkdown.lib
+PGMS=
+SAMPLE_PGMS=mkd2html
+
+# Assumes VERSION is a single-line file
+VERSION = \
+	!INCLUDE <VERSION>
+
+default:	all
+
+all:	$(MKDLIB) $(PGMS) $(SAMPLE_PGMS) 
+
+$(MKDLIB):	$(LIBOBJ)
+	if exist $(MKDLIB) del $(MKDLIB)
+	lib /out:$(MKDLIB) $(LIBOBJ)
+
+config.h: msvc/config.h.vc
+	copy /Y msvc\config.h.vc config.h
+
+version.c: version.c.in
+	powershell.exe -Command "(gc version.c.in) -replace '@TABSTOP@', 'TABSTOP' | Out-File version.c"
+
+version.obj: version.c VERSION config.h
+	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" /c version.c
+
+mkdio.h: mkdio.h.in
+	powershell.exe -Command "(gc mkdio.h.in) -replace '@DWORD@', 'unsigned long' | Out-File mkdio.h"
+
+mkdio.obj: mkdio.h
+
+tags.obj: tags.c cstring.h tags.h blocktags
+
+mktags: mktags.obj
+	$(CC) $(CFLAGS) mktags.obj
+
+blocktags: mktags
+	.\mktags.exe > blocktags
+
+mkd2html:  mkd2html.obj $(MKDLIB) mkdio.h gethopt.h gethopt.obj
+	$(CC) $(CFLAGS) $(LFLAGS) mkd2html.obj gethopt.obj $(MKDLIB)
+
+pgm_options.obj: pgm_options.c mkdio.h config.h
+	$(CC) $(CFLAGS) -I. pgm_options.c
+
+clean:
+	-del config.h blocktags mkdio.h version.c
+	-del *.obj *.lib
+	-del *.pdb *.exp
+	-del *.ilk *.exe

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -1,0 +1,10 @@
+# *Discount* Markdown compiler on Windows with Visual C++
+
+Makefile for NMAKE utility to build Discount using Visual C++
+and pre-digested `config.h` template.
+
+## Build
+
+    nmake /f msvc/Makefile
+    nmake /f msvc/Makefile clean
+

--- a/msvc/config.h.vc
+++ b/msvc/config.h.vc
@@ -1,0 +1,75 @@
+/*
+ * Pre-digested configuration header for MSVC on Windows.
+ */
+
+#ifndef __AC_MARKDOWN_D
+#define __AC_MARKDOWN_D 1
+
+#ifndef _MSC_VER
+#error Use this header with MSVC only.
+#endif
+
+#define OS_WIN32 1
+
+/*
+ * `discount` feature macros - we want them all!
+ */
+#ifndef WITH_ID_ANCHOR
+#define WITH_ID_ANCHOR 1
+#endif
+#ifndef WITH_FENCED_CODE
+#define WITH_FENCED_CODE 1
+#endif
+#ifndef WITH_GITHUB_TAGS
+#define WITH_GITHUB_TAGS 1
+#endif
+#ifndef USE_DISCOUNT_DL
+#define USE_DISCOUNT_DL 1
+#endif
+#ifndef USE_EXTRA_DL
+#define USE_EXTRA_DL 1
+#endif
+
+/*
+ * The Visual C++ "C" compiler has a `__inline` keyword implemented
+ * in Visual Studio 2008 and later, see
+ * <http://msdn.microsoft.com/de-de/library/cx3b23a3%28v=vs.90%29.aspx>
+ */
+#if _MSC_VER >= 1500 /* VC 9.0, MSC_VER 15, Visual Studio 2008 */
+#define inline __inline
+#else
+#define inline 
+#endif
+
+#ifdef _MSC_VER
+#ifndef strncasecmp
+#include <string.h>
+#define bzero(p, n) memset(p, 0, n)
+#define strcasecmp _stricmp 
+#define strncasecmp _strnicmp
+#endif
+#endif
+
+/*
+ * Beware of conflicts with <Windows.h>, which typedef's these names.
+ */
+#ifndef WINVER
+#define DWORD unsigned long
+#define WORD  unsigned short
+#define BYTE  unsigned char
+#endif
+
+#define HAVE_PWD_H 0
+#define HAVE_GETPWUID 0
+#define HAVE_SRANDOM 0
+#define INITRNG(x) srand((unsigned int)x)
+#define HAVE_BZERO 0
+#define HAVE_RANDOM 0
+#define COINTOSS() (rand()&1)
+#define HAVE_STRCASECMP  1
+#define HAVE_STRNCASECMP 1
+#define HAVE_FCHDIR 0
+#define TABSTOP 8
+#define HAVE_MALLOC_H    0
+
+#endif /* __AC_MARKDOWN_D */


### PR DESCRIPTION
Add pre-digested config.h for Visual C++ on Windows (courtesy of @tin-pot's [fork of Discount](https://github.com/tin-pot/discount) with slight update and simplification).

Basic MSVC configuration allows to build `libmarkdown` and `mkd2html` utility.

-----
Successful build tested with Visual C++ from VS2015 on Windows 10.
Addresses issue #154.