### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+script:
+  - ./configure.sh
+  - make
+
+after_success:
+  - make test


### PR DESCRIPTION
* Allows to run CI builds on Travis CI with gcc and clang.
* Runs `make test`.

------

NOTE: Requires to flick the repository switch on for Orc/discount repo in Travis CI https://travis-ci.org/profile/