### PR TITLE
notspecial: do a positive check. (fixes plan9, improves others)

### DIFF
--- a/notspecial.c
+++ b/notspecial.c
@@ -17,7 +17,7 @@ notspecial(char *file)
     if ( stat(file, &info) != 0 )
 	return 1;
     
-    return !( S_ISCHR(info.st_mode) || S_ISFIFO(info.st_mode) || S_ISSOCK(info.st_mode) );
+    return S_ISREG(info.st_mode);
 }
 #else
 int


### PR DESCRIPTION
Currently, notspecial() checks for a list of special types of
file, instead of checking if the file is regular. It seems like
checking for what we want is likely to be more useful than
checking for things we want to avoid -- especially since the
list of special things is far more likely to grow.