### PR TITLE
Fix build under compilers that don't support {} as a array initializer

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -566,11 +566,11 @@ static linkytype linkt  = { 0, 0, "<a href=\"", "\"",
  * raw: just dump the link without any processing
  */
 static linkytype specials[] = {
-    { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", {}, 0 },
+    { "id:", 3, "<span id=\"", "\"", 0, ">", "</span>", {0}, 0 },
     { "raw:", 4, 0, 0, 0, 0, 0, { { [MKD_NOHTML] = 1 } }, 0 },
-    { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", {}, 0 },
-    { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", {}, 0 },
-    { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", {}, 0 },
+    { "lang:", 5, "<span lang=\"", "\"", 0, ">", "</span>", {0}, 0 },
+    { "abbr:", 5, "<abbr title=\"", "\"", 0, ">", "</abbr>", {0}, 0 },
+    { "class:", 6, "<span class=\"", "\"", 0, ">", "</span>", {0}, 0 },
 } ;
 
 #define NR(x)	(sizeof x / sizeof x[0])


### PR DESCRIPTION
Using `{}` to zero-initialize arrays seems to be a GCC-specific extensions, not accepted by some compilers such as the Plan 9 compiler suite or MSVC; this changes occurrences of `{}` to `{0}`.

Changes tested on 9front/386, test suite passes.
