### PR TITLE
docs: fix simple typo, inport -> import

### DIFF
--- a/toc.c
+++ b/toc.c
@@ -15,7 +15,7 @@
 #include "markdown.h"
 #include "amalloc.h"
 
-/* inport from Csio.c */
+/* import from Csio.c */
 extern void Csreparse(Cstring *, char *, int, mkd_flag_t*);
     
 /* write an header index


### PR DESCRIPTION
There is a small typo in toc.c.

Should read `import` rather than `inport`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md