### PR TITLE
Support ^superscript^ ~subscript~ and ==highlight==

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -911,6 +911,37 @@ delspan(MMIOT *f, int size)
     Qstring("</del>", f);
 }
 
+/*  subspan() -- write out a chunk of text, blocking with <sub>...</sub>
+ */
+static void
+subspan(MMIOT *f, int size)
+{
+    Qstring("<sub>", f);
+    ___mkd_reparse(cursor(f)-1, size, 0, f, 0);
+    Qstring("</sub>", f);
+}
+
+/*  suppan() -- write out a chunk of text, blocking with <sup>...</sup>
+ */
+static void
+supspan(MMIOT *f, int size)
+{
+    Qstring("<sup>", f);
+    ___mkd_reparse(cursor(f)-1, size, 0, f, 0);
+    Qstring("</sup>", f);
+}
+
+/*  highlightspan() -- write out a chunk of text, blocking with <span style="background-color:yellow">...</span>
+ */
+static void
+highlightspan(MMIOT *f, int size)
+{
+    Qstring("<span style=\"background-color:yellow\">", f);
+    ___mkd_reparse(cursor(f)-1, size, 0, f, 0);
+    Qstring("</span>", f);
+}
+
+
 
 /*  codespan() -- write out a chunk of text as code, trimming one
  *                space off the front and/or back as appropriate.
@@ -1350,44 +1381,22 @@ text(MMIOT *f)
 	case '[':   if ( tag_text(f) || !linkylinky(0, f) )
 			Qchar(c, f);
 		    break;
-	/* A^B -> A<sup>B</sup> */
-	case '^':   if ( is_flag_set(f->flags, MKD_NOSUPERSCRIPT)
-			    || is_flag_set(f->flags, MKD_STRICT)
-			    || is_flag_set(f->flags, MKD_TAGTEXT)
-			    || (f->last == 0)
-			    || ((ispunct(f->last) || isspace(f->last))
-						    && f->last != ')')
-			    || isthisspace(f,1) )
-			Qchar(c,f);
-		    else {
-			char *sup = cursor(f);
-			int len = 0;
-
-			if ( peek(f,1) == '(' ) {
-			    int here = mmiottell(f);
-			    pull(f);
-
-			    if ( (len = parenthetical('(',')',f)) <= 0 ) {
-				mmiotseek(f,here);
-				Qchar(c, f);
-				break;
-			    }
-			    sup++;
-			}
-			else {
-			    while ( isthisalnum(f,1+len) )
-				++len;
-			    if ( !len ) {
-				Qchar(c,f);
-				break;
-			    }
-			    shift(f,len);
-			}
-			Qstring("<sup>",f);
-			___mkd_reparse(sup, len, 0, f, "()");
-			Qstring("</sup>", f);
-		    }
+	
+	case '=': if ( is_flag_set(f->flags, MKD_NOSUPERSCRIPT)
+			 || is_flag_set(f->flags, MKD_STRICT)
+			 || is_flag_set(f->flags, MKD_TAGTEXT)
+			 || ! tickhandler(f,c,2,0, highlightspan))
+			Qchar(c, f);
 		    break;
+
+	/* A^B^ -> A<sup>B</sup> */
+	case '^':   if ( is_flag_set(f->flags, MKD_NOSUPERSCRIPT)
+			 || is_flag_set(f->flags, MKD_STRICT)
+			 || is_flag_set(f->flags, MKD_TAGTEXT)
+			 || ! tickhandler(f,c,1,0, supspan))
+			Qchar(c, f);
+		    break;
+
 	case '_':
 	/* Underscores don't count if they're in the middle of a word */
 		    if ( !(is_flag_set(f->flags, MKD_NORELAXED) || is_flag_set(f->flags, MKD_STRICT))
@@ -1415,7 +1424,7 @@ text(MMIOT *f)
 	case '~':   if ( is_flag_set(f->flags, MKD_NOSTRIKETHROUGH)
 			 || is_flag_set(f->flags, MKD_STRICT)
 			 || is_flag_set(f->flags, MKD_TAGTEXT)
-			 || ! tickhandler(f,c,2,0, delspan) )
+			 || ! (tickhandler(f,c,2,0, delspan) || tickhandler(f,c,1,0, subspan)))
 			Qchar(c, f);
 		    break;
 

--- a/markdown.c
+++ b/markdown.c
@@ -215,7 +215,7 @@ checkline(Line *l, mkd_flag_t flags)
 	switch (c) {
 	case '-':  UNLESS_FENCED(dashes = 1); break;
 	case ' ':  UNLESS_FENCED(spaces = 1); break;
-	case '=':  equals = 1; break;
+	case '=':  UNLESS_FENCED(equals = 1); break;
 	case '_':  UNLESS_FENCED(underscores = 1); break;
 	case '*':  stars = 1; break;
 	default:

--- a/test.md
+++ b/test.md
@@ -1,0 +1,30 @@
+## Title
+
+Some text
+
+x^2  x^(a+b)^  x^a+b^
+
+H~2~O
+
+some thext with footnotne[^1]
+
+[^1]: Footnote content
+
+some other text
+
+~strike~
+
+~~strike~~
+
+*italic*
+
+**bold**
+
+_italic_
+
+__bold__
+
+==X^2^   X^a+b^   H~2~O==
+
+
+


### PR DESCRIPTION
I'm using Discount in a simple content server to render Markdown files to HTML. I tried to make it fully server side solution without using javascript on the client side. The Markdown pages are authored using Typora. I found that Discount is not 100% compatible with the editor:
 - superscript in Typora (and actually other Markdown implementations) expect ^ to be used before and after the text, e.g. x^2^
 - superscript in Typora does not expect the brackets ()
 - Discount does not support subscript e.g. H~2~O
 - Discount does not support ==highlighting text==
 There are more differences, and Typora also lacks some of Discount's features, but I wanted at least to implemented these 3 listed above.

You will find my attempt in this pull request. I would like to hear your comments and whether you consider accepting my changes.

Note that all 3 formatting features respond to the single configuration flag which was initially used only for superscript.  