### PR TITLE
Makefile.in: add missing make depend to pandoc_headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -140,7 +140,7 @@ test:	$(PGMS) $(TESTFRAMEWORK) verify
 
 pandoc_headers.o: tools/pandoc_headers.c config.h
 	$(BUILD) -c -o pandoc_headers.o tools/pandoc_headers.c
-pandoc_headers: pandoc_headers.o $(MKDLIB)
+pandoc_headers: pandoc_headers.o $(COMMON) $(MKDLIB)
 	$(LINK) -o pandoc_headers pandoc_headers.o $(COMMON) -lmarkdown 
 
 branch.o: tools/branch.c config.h


### PR DESCRIPTION
Noticed missing pgm_options.o prerequisite dependency when built
package in parallel:

    $ make -j16 -l16 -k
    gcc -L. -g -o pandoc_headers pandoc_headers.o pgm_options.o gethopt.o notspecial.o -lmarkdown
    ld: cannot find pgm_options.o: No such file or directory
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:144: pandoc_headers] Error 1
    gcc -I.  -g -fPIC -c pgm_options.c

It's also visible when we try to build a single target:

    $ make pandoc_headers
    <same failure>

The change adds $(COMMON) dependency used during linking
in pandoc_headers.