### PR TITLE
Plan9/mkfile: Don't build mktags nor generate blocktags

### DIFF
--- a/Plan9/README.md
+++ b/Plan9/README.md
@@ -1,33 +1,44 @@
 # *Discount* Markdown compiler on Plan 9
 
 ## Build
+
+### One line
+
+    % mk install
+    % markdown -V
+    markdown: discount X.Y.Z GHC=INPUT
+
+### Stepwise
+
     % CONFIG='--with-tabstops=7' mk config
+    % mk
     % mk test
     % mk install
     % markdown -V
-    markdown: discount X.Y.Z TAB=7
+    markdown: discount X.Y.Z TAB=7 GHC=INPUT
 
-### Configuration
-To select features and extensions, `--with-tabstops=7` may be replaced by zero or more of:
+See `../configure.sh` and `../pgm_options.c` for other config options.
 
-* `--enable-pandoc-header`:  Use pandoc-style header blocks
-* `--enable-superscript`:  `A^B` becomes A<sup>B</sup>
-* `--enable-amalloc`:  Enable memory allocation debugging
-* `--with-tabstops=`*N*:  Set tabstops to *N* characters (default 4)
-* `--enable-alpha-list`:  Enable `(a)/(b)/(c)` list markers
-* `--enable-all-features`:  Turn on all stable optional features
+### Other *mk*(1) targets
+
+* `clean`: Delete built objects from source directory.
+* `nuke`: Delete built objects and generated configuration.
+* `install.libs`:  Discount includes a C library and header.
+Installation is optional.  Plan 9 binaries are statically linked.
+* `install.man`:  Add *markdown* in manual sections 1, 2, and 6.
+* `install.progs`:  Extra programs.  *makepage* writes complete
+XHTML documents, rather than fragments.  *mkd2html* is similar,
+but produces HTML.
+* `installall`: Do all `install*` targets above.
+* `uninstall`: Remove anything added by `install*` targets above.
 
 ## Notes
-1. This is not a port from POSIX to native Plan 9 APIs. The supplied
-`mkfile` merely drives Discount's own `configure.sh` through Plan 9's
-*APE* environment (in *pcc*(1)) to build the Discount source, then
-copies the result to locations appropriate for system-wide use on
-Plan 9.
 
-2. There are a few other *mk*(1) targets:
-    * `install.libs`:  Discount includes a C library and header.
-Installation is optional.  Plan 9 binaries are statically linked.
-    * `install.man`:  Add manual pages for *markdown* in sections 1, 2, and 6.
-    * `install.progs`:  Extra programs.  *makepage* writes complete XHTML
-documents, rather than fragments.  *mkd2html* is similar, but produces
-HTML.
+This is not a port from POSIX to native Plan 9 APIs. The supplied
+`mkfile` drives Discount's own `../configure.sh` and the `../Makefile`
+it generates through [Plan 9's ANSI/POSIX Environment (APE)][ape-paper]
+(in [*pcc*(1)][pcc-man]) to build the Discount source, then copies
+the results to locations appropriate for system-wide use on Plan 9.
+
+[ape-paper]: https://plan9.io/sys/doc/ape.html
+[pcc-man]: https://plan9.io/magic/man2html/1/pcc

--- a/Plan9/mkfile
+++ b/Plan9/mkfile
@@ -5,10 +5,10 @@ CFLAGS='-D_BSD_EXTENSION -D_C99_SNPRINTF_EXTENSION'
 markdown:V:	../markdown
 
 ../markdown: ../config.h
-	ape/psh -c 'cd .. && $CC mktags.c -o mktags && ./mktags > blocktags && make'
+	ape/psh -c 'cd .. && make'
 
 test: markdown
-	ape/psh -c 'cd ..&& make test'
+	ape/psh -c 'cd .. && make test'
 
 install:V: ../markdown
 	cp ../markdown $BIN/markdown


### PR DESCRIPTION
Remove the obsolete workaround of directly building mktags
and running it in Plan9/mkfile. The upstairs configure.sh
and make no longer fails to generate the blocktags file.

Update Plan9/README.md generally.