### PR TITLE
tests/tabstop.t: Literal newline for tr(1)

### DIFF
--- a/tests/tabstop.t
+++ b/tests/tabstop.t
@@ -4,7 +4,8 @@ rc=0
 unset MARKDOWN_FLAGS
 unset MKD_TABSTOP
 
-eval `./markdown -V | tr ' ' '\n' | grep TAB`
+eval `./markdown -V | tr ' ' '
+' | grep TAB`
 
 if [ "${TAB:-4}" -eq 8 ]; then
     title "dealing with tabstop derangement"


### PR DESCRIPTION
**This change may be Plan 9-only**. A PR gives me an easy way to illustrate the bug.

Plan 9 tr(1) represents a newline with a literal newline. The \n
sequence yields the letter "n". So in tests/tabstop.t:7 the eval
yields "tests/tabstop.t: markdown:ndiscountn3nTAB=7nGHC=INPUT: not found"
from a make tests run.

If you do just the eval in straight ape/psh, no interceding mk:
    % ape/psh
    $ ./markdown -V
    markdown: discount 3 TAB=7 GHC=INPUT
    $ eval `./markdown -V | tr ' ' '\n' | grep TAB`
    /bin/sh: markdown:ndiscountn3nTAB=7nGHC=INPUT: not found

This change makes the eval and thus the tabstop test work on
Plan 9, but I'm not sure beyond a quick test if it is OK to
throw a literal newline at GNU or other tr(1).