### PR TITLE
GitHub/GitLab -like README generation

### DIFF
--- a/basename.c
+++ b/basename.c
@@ -18,7 +18,7 @@ static char *
 e_basename(const char *string, const int size, void *context)
 {
     char *ret;
-    char *base = (char*)context;
+    char *base = ((char **)context)[0];
     
     if ( base && string && (*string == '/') && (ret=malloc(strlen(base)+size+2)) ) {
 	strcpy(ret, base);
@@ -28,16 +28,36 @@ e_basename(const char *string, const int size, void *context)
     return 0;
 }
 
+static char *
+e_anchorid(const char *string, const int size, void *context)
+{
+    char *anchorid = ((char **)context)[1];
+    return strdup(anchorid);
+}
+
 static void
 e_free(char *string, void *context)
 {
     if ( string ) free(string);
 }
 
+/* basename uses index 0, anchorid 1 */
+static char *data[2] = {0};
+
 void
 mkd_basename(MMIOT *document, char *base)
 {
+    data[0] = base;
     mkd_e_url(document, e_basename);
-    mkd_e_data(document, base);
+    mkd_e_data(document, data);
+    mkd_e_free(document, e_free);
+}
+
+void
+mkd_anchorid(MMIOT *document, char *anchorid)
+{
+    data[1] = anchorid;
+    mkd_e_anchorid(document, e_anchorid);
+    mkd_e_data(document, data);
     mkd_e_free(document, e_free);
 }

--- a/flags.c
+++ b/flags.c
@@ -32,6 +32,7 @@ static struct flagnames flagnames[] = {
     { MKD_DLEXTRA,        "DLEXTRA" },
     { MKD_FENCEDCODE,     "FENCEDCODE" },
     { MKD_IDANCHOR,       "IDANCHOR" },
+    { MKD_TAGANCHOR,      "TAGANCHOR" },
     { MKD_GITHUBTAGS,     "GITHUBTAGS" },
     { MKD_NORMAL_LISTITEM,  "NORMAL_LISTITEM" },
     { MKD_URLENCODEDANCHOR, "URLENCODEDANCHOR" },

--- a/generate.c
+++ b/generate.c
@@ -1679,14 +1679,16 @@ printtable(Paragraph *pp, MMIOT *f)
     return 1;
 }
 
-
 static Line *
 printfenced(Line *t, MMIOT *f)
 {
     Qstring("<pre><code", f);
     if ( t->fence_class )
 	Qprintf(f, " class=\"%s\"", t->fence_class);
-    Qstring(">\n", f);
+    Qstring(">", f);
+    if ( !is_flag_set(&f->flags, MKD_FENCEDINLINE) )
+        Qchar('\n', f);
+
     while ( (t = t->next) && t->is_fenced ) {
 	code(f, T(t->text), S(t->text));
 	Qchar('\n', f);

--- a/generate.c
+++ b/generate.c
@@ -1523,7 +1523,23 @@ text(MMIOT *f)
 static void
 printheader(Paragraph *pp, MMIOT *f)
 {
-    if ( is_flag_set(&f->flags, MKD_IDANCHOR) ) {
+    if ( is_flag_set(&f->flags, MKD_TAGANCHOR) ) {
+	if ( pp->label && is_flag_set(&f->flags, MKD_TOC) ) {
+	    char *prefix = NULL;
+	    if (f->cb && f->cb->e_anchorid)
+		prefix = (*(f->cb->e_anchorid))(pp->label, strlen(pp->label), f->cb->e_data);
+
+	    Qprintf(f, "<h%d id=\"%s", pp->hnumber, prefix ? prefix : "discount-");
+	    Qanchor(pp->label, f);
+	    Qprintf(f, "\"><a class=\"anchor\" href=\"#%s", prefix ? prefix : "discount-");
+	    Qanchor(pp->label, f);
+	    Qstring("\"></a>", f);
+
+	    if (f->cb && f->cb->e_anchorid && f->cb->e_free)
+		(*(f->cb->e_free))(prefix, f->cb->e_data);
+	} else
+	    Qprintf(f, "<h%d>", pp->hnumber);
+    } else if ( is_flag_set(&f->flags, MKD_IDANCHOR) ) {
 	Qprintf(f, "<h%d", pp->hnumber);
 	if ( pp->label && is_flag_set(&f->flags, MKD_TOC) ) {
 	    Qstring(" id=\"", f);

--- a/gethopt.3
+++ b/gethopt.3
@@ -30,7 +30,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd Jan 23, 2017
+.Dd Jun 27, 2022
 .Dt GETHOPT 3
 .Os Mastodon
 .Sh NAME
@@ -60,6 +60,10 @@ struct h_opt {
 .Fn hoptset "struct h_context* argctx" "int argc" "char** argv"
 .Ft struct h_opt*
 .Fn gethopt "struct h_context* argctx" "struct h_opt* optarray" "int nropts"
+.Ft void
+.Fn hoptusage "char *progname" "struct h_opt* optarray" "int nropts" "char *arguments"
+.Ft void
+.Fn hopthelp "char *progname" "struct h_opt* optarray" "int nropts"
 
 .Sh DESCRIPTION
 The
@@ -113,7 +117,7 @@ returns
 .Dv HOPTERR
 if a non-recognized
 option is encountered,
-and NULL when it reaches the end of the options on the command line..
+and NULL when it reaches the end of the options on the command line.
 .Pp
 The interpretation of options in the argument list may be cancelled
 by 
@@ -129,6 +133,11 @@ argument),
 .Fn gethopt
 returns
 .Dv NULL .
+.Pp
+.Fn hoptusage
+and
+.Fn hopthelp
+respectively print out short and long command line parameter help texts.
 .Sh DIAGNOSTICS
 If the
 .Fn gethopt

--- a/gethopt.c
+++ b/gethopt.c
@@ -232,6 +232,36 @@ hoptusage(char *pgm, struct h_opt opts[], int nropts, char *arguments)
     fputc('\n', stderr);
 }
 
+void
+hopthelp(char *pgm, struct h_opt opts[], int nropts)
+{
+    int i;
+
+    fprintf(stdout, "help: %s\n", pgm);
+
+    /* print combined long and short options */
+    for ( i=0; i < nropts; i++ ) {
+	if ( opts[i].optchar && opts[i].optword) {
+		fprintf(stdout, "-%c, -%s", opts[i].optchar, opts[i].optword);
+		if ( opts[i].optdesc )
+		    fprintf(stdout, "\t%s", opts[i].optdesc);
+
+		fputc('\n', stdout);
+	}
+    }
+
+    /* print short options */
+    for ( i=0; i < nropts; i++ ) {
+	if ( opts[i].optchar && !opts[i].optword) {
+		fprintf(stdout, "-%c", opts[i].optchar);
+		if ( opts[i].optdesc )
+		    fprintf(stdout, "\t\t%s", opts[i].optdesc);
+
+		fputc('\n', stdout);
+	}
+    }
+}
+
 
 #if DEBUG
 struct h_opt opts[] = {

--- a/gethopt.h
+++ b/gethopt.h
@@ -39,5 +39,6 @@ extern int   hopterr(struct h_context *, int);
 extern struct h_opt *gethopt(struct h_context *, struct h_opt*, int);
 
 extern void hoptusage(char *, struct h_opt*, int, char *);
+extern void hopthelp(char *, struct h_opt*, int);
 
 #endif/*__GETHOPT_D*/

--- a/main.c
+++ b/main.c
@@ -159,6 +159,7 @@ struct h_opt opts[] = {
     { 0, 0,        'o', "file",      "write output to file" },
     { 0, "squash", 'x', 0,           "squash toc labels to be more like github" },
     { 0, "codefmt",'X', 0,           "use an external code formatter" },
+    { 0, "help",   'h', 0,           "print help" },
 };
 #define NROPTS (sizeof opts/sizeof opts[0])
 
@@ -267,6 +268,9 @@ main(int argc, char **argv)
 		    break;
 	case 'X':   use_e_codefmt = 1;
 		    mkd_set_flag_num(flags, MKD_FENCEDCODE);
+		    break;
+	case 'h':   hopthelp(pgm, opts, NROPTS);
+		    exit(0);
 		    break;
 	}
     }

--- a/main.c
+++ b/main.c
@@ -159,6 +159,7 @@ struct h_opt opts[] = {
     { 0, 0,        'o', "file",      "write output to file" },
     { 0, "squash", 'x', 0,           "squash toc labels to be more like github" },
     { 0, "codefmt",'X', 0,           "use an external code formatter" },
+    { 0, "anchorid",'a',"anchorid",  "prefix for heading <a> anchor ids" },
     { 0, "help",   'h', 0,           "print help" },
 };
 #define NROPTS (sizeof opts/sizeof opts[0])
@@ -182,6 +183,7 @@ main(int argc, char **argv)
     char *text = 0;
     char *ofile = 0;
     char *urlbase = 0;
+    char *anchorid = 0;
     char *q;
     MMIOT *doc;
     struct h_context blob;
@@ -206,6 +208,8 @@ main(int argc, char **argv)
 	}
 	switch (opt->optchar) {
 	case '5':   with_html5 = 1;
+		    break;
+	case 'a':   anchorid = hoptarg(&blob);
 		    break;
 	case 'b':   urlbase = hoptarg(&blob);
 		    break;
@@ -316,6 +320,8 @@ main(int argc, char **argv)
 		exit(1);
 	    }
 	}
+	if ( anchorid )
+	    mkd_anchorid(doc, anchorid);
 	if ( urlbase )
 	    mkd_basename(doc, urlbase);
 	if ( urlflags ) {

--- a/markdown.1
+++ b/markdown.1
@@ -126,6 +126,8 @@ Allow markdown extra-style footnotes.
 Extract <style> blocks from the output.
 .It Ar fencedcode
 Allow fenced code blocks (not default).
+.It Ar fencedinline
+Remove newline following <code> block in fenced code (not default).
 .It Ar idanchor
 Use id= anchors for table-of-contents links instead of <a name=/> (not default).
 .It Ar taganchor

--- a/markdown.1
+++ b/markdown.1
@@ -11,6 +11,7 @@
 .Op Fl d
 .Op Fl T
 .Op Fl V
+.Op Fl a, Fl anchor Ar anchorid
 .Op Fl b Ar url-base
 .Op Fl C Ar prefix
 .Op Fl F Pa bitmap
@@ -34,6 +35,9 @@ to stdout.
 .Pp
 The options are as follows:
 .Bl -tag -width "-o file"
+.It Fl a Ar anchorid
+Sets the prefix that is used by heading <a class="anchor"> tags.
+Requires -ftoc,taganchor.
 .It Fl b Ar url-base
 Links in source beginning with / will be prefixed with
 .Ar url-base
@@ -124,6 +128,8 @@ Extract <style> blocks from the output.
 Allow fenced code blocks (not default).
 .It Ar idanchor
 Use id= anchors for table-of-contents links instead of <a name=/> (not default).
+.It Ar taganchor
+Use <a class="anchor" href="..."> anchors for table-of-contents links (not default).
 .It Ar githubtags
 Allow underscore and dash in passed through element names (not default).
 .It Ar urlencodedanchor

--- a/markdown.3
+++ b/markdown.3
@@ -116,6 +116,8 @@ Do not extract (omit) <style/> blocks from the output.
 Allow fenced code blocks.
 .It Ar MKD_IDANCHOR
 Use id= anchors instead of <a name=/> for table-of-contents links.
+.It Ar MKD_TAGANCHOR
+Use <a class="anchor" href="..."> anchors for table-of-contents links.
 .It Ar MKD_GITHUBTAGS
 Allow underscore and dash in passed through element names.
 .It Ar MKD_URLENCODEDANCHOR

--- a/markdown.3
+++ b/markdown.3
@@ -114,6 +114,8 @@ Enable markdown extra-style footnotes.
 Do not extract (omit) <style/> blocks from the output.
 .It Ar MKD_FENCEDCODE
 Allow fenced code blocks.
+.It Ar MKD_FENCEDINLINE
+Remove newline following <code> block in fenced code (not default).
 .It Ar MKD_IDANCHOR
 Use id= anchors instead of <a name=/> for table-of-contents links.
 .It Ar MKD_TAGANCHOR

--- a/markdown.h
+++ b/markdown.h
@@ -40,6 +40,7 @@ enum {  MKD_NOLINKS=0,		/* don't do link processing, block <a> tags  */
 	MKD_DLEXTRA,		/* enable extra-style definition lists */
 	MKD_FENCEDCODE,		/* enabled fenced code blocks */
 	MKD_IDANCHOR,		/* use id= anchors for TOC links */
+	MKD_TAGANCHOR,          /* use <a class="anchor"> anchors for TOC links */
 	MKD_GITHUBTAGS,		/* allow dash and underscore in element names */
 	MKD_URLENCODEDANCHOR,	/* urlencode non-identifier chars instead of replacing with dots */
 	MKD_LATEX,		/* handle embedded LaTeX escapes */
@@ -150,6 +151,7 @@ typedef struct callback_data {
     mkd_callback_t e_url;	/* url edit callback */
     mkd_callback_t e_flags;	/* extra href flags callback */
     mkd_callback_t e_anchor;	/* callback for anchor types */
+    mkd_callback_t e_anchorid;  /* callback for anchor id */
     mkd_free_t e_free;		/* edit/flags callback memory deallocator */
     mkd_callback_t e_codefmt;	/* codeblock formatter (for highlighting) */
 } Callback_data;
@@ -255,6 +257,7 @@ extern int  mkd_line(char *, int, char **, mkd_flag_t*);
 extern int  mkd_generateline(char *, int, FILE*, mkd_flag_t*);
 #define mkd_text mkd_generateline
 extern void mkd_basename(Document*, char *);
+extern void mkd_anchorid(Document*, char *);
 
 typedef int (*mkd_sta_function_t)(const int,const void*);
 extern void mkd_string_to_anchor(char*,int, mkd_sta_function_t, void*, int, MMIOT *);

--- a/markdown.h
+++ b/markdown.h
@@ -39,6 +39,7 @@ enum {  MKD_NOLINKS=0,		/* don't do link processing, block <a> tags  */
 	MKD_DLDISCOUNT,		/* enable discount-style definition lists */
 	MKD_DLEXTRA,		/* enable extra-style definition lists */
 	MKD_FENCEDCODE,		/* enabled fenced code blocks */
+    MKD_FENCEDINLINE,   /* don't format fenced code */
 	MKD_IDANCHOR,		/* use id= anchors for TOC links */
 	MKD_TAGANCHOR,          /* use <a class="anchor"> anchors for TOC links */
 	MKD_GITHUBTAGS,		/* allow dash and underscore in element names */

--- a/mkd-callbacks.3
+++ b/mkd-callbacks.3
@@ -36,6 +36,8 @@ library user modify the generated html.
  adds additional flags to a `[]` link;
 .It Fn mkd_e_code 
 lets you manipulate the contents of a code block.
+.It Fn mkd_e_anchorid
+lets you set the prefix of a heading <a> anchor id.
 .El
 .Pp
 The data access functions are passed a character pointer to

--- a/mkdio.c
+++ b/mkdio.c
@@ -415,6 +415,18 @@ mkd_e_anchor(Document *f, mkd_callback_t format)
     }
 }
 
+/* set the anchor id getter
+ */
+void
+mkd_e_anchorid(Document *f, mkd_callback_t anchorid)
+{
+    if ( f ) {
+	if ( f->cb.e_anchorid != anchorid )
+	    f->dirty = 1;
+	f->cb.e_anchorid = anchorid;
+    }
+}
+
 
 /* set the url display/options deallocator
  */

--- a/mkdio.h.in
+++ b/mkdio.h.in
@@ -37,6 +37,7 @@ enum {  MKD_NOLINKS=0,		/* don't do link processing, block <a> tags  */
 	MKD_DLEXTRA,		/* enable extra-style definition lists */
 	MKD_FENCEDCODE,		/* enabled fenced code blocks */
 	MKD_IDANCHOR,		/* use id= anchors for TOC links */
+	MKD_TAGANCHOR,          /* use <a class="anchor"> anchors for TOC links */
 	MKD_GITHUBTAGS,		/* allow dash and underscore in element names */
 	MKD_URLENCODEDANCHOR,	/* urlencode non-identifier chars instead of replacing with dots */
 	MKD_LATEX,		/* handle embedded LaTeX escapes */
@@ -82,6 +83,7 @@ MMIOT *gfm_in(FILE*,mkd_flag_t*);		/* assemble input from a file */
 MMIOT *gfm_string(const char*,int,mkd_flag_t*);	/* assemble input from a buffer */
 
 void mkd_basename(MMIOT*,char*);
+void mkd_anchorid(MMIOT*,char*);
 
 void mkd_initialize();
 void mkd_with_html5_tags();
@@ -130,6 +132,7 @@ typedef void   (*mkd_free_t)(char*, void*);
 void mkd_e_url(void *, mkd_callback_t);
 void mkd_e_flags(void *, mkd_callback_t);
 void mkd_e_anchor(void *, mkd_callback_t);
+void mkd_e_anchorid(void *, mkd_callback_t);
 void mkd_e_code_format(void*, mkd_callback_t);
 void mkd_e_free(void *, mkd_free_t );
 void mkd_e_data(void *, void *);

--- a/mkdio.h.in
+++ b/mkdio.h.in
@@ -36,6 +36,7 @@ enum {  MKD_NOLINKS=0,		/* don't do link processing, block <a> tags  */
 	MKD_DLDISCOUNT,		/* enable discount-style definition lists */
 	MKD_DLEXTRA,		/* enable extra-style definition lists */
 	MKD_FENCEDCODE,		/* enabled fenced code blocks */
+    MKD_FENCEDINLINE,   /* don't format fenced code */
 	MKD_IDANCHOR,		/* use id= anchors for TOC links */
 	MKD_TAGANCHOR,          /* use <a class="anchor"> anchors for TOC links */
 	MKD_GITHUBTAGS,		/* allow dash and underscore in element names */

--- a/pgm_options.c
+++ b/pgm_options.c
@@ -70,6 +70,7 @@ static struct _opt {
     { "dlextra",       "markdown extra-style definition lists", 0, 0, 0, 1, MKD_DLEXTRA },
     { "fencedcode",    "fenced code blocks",         0, 0, 0, 1, MKD_FENCEDCODE },
     { "idanchor",      "id= anchors in TOC",         0, 0, 0, 1, MKD_IDANCHOR },
+    { "taganchor",     "<a class=\"anchor\"> in TOC",0, 0, 0, 1, MKD_TAGANCHOR },
     { "githubtags",    "- and _ in element names",   0, 0, 0, 1, MKD_GITHUBTAGS },
     { "urlencodedanchor", "html5-style anchors",     0, 0, 0, 1, MKD_URLENCODEDANCHOR },
     { "html5anchor",   "html5-style anchors",        0, 0, 1, 1, MKD_URLENCODEDANCHOR },

--- a/pgm_options.c
+++ b/pgm_options.c
@@ -69,6 +69,7 @@ static struct _opt {
     { "dldiscount",    "discount-style definition lists", 0, 0, 0, 1, MKD_DLDISCOUNT },
     { "dlextra",       "markdown extra-style definition lists", 0, 0, 0, 1, MKD_DLEXTRA },
     { "fencedcode",    "fenced code blocks",         0, 0, 0, 1, MKD_FENCEDCODE },
+    { "fencedinline",  "don't format fenced code",   0, 0, 0, 1, MKD_FENCEDINLINE },
     { "idanchor",      "id= anchors in TOC",         0, 0, 0, 1, MKD_IDANCHOR },
     { "taganchor",     "<a class=\"anchor\"> in TOC",0, 0, 0, 1, MKD_TAGANCHOR },
     { "githubtags",    "- and _ in element names",   0, 0, 0, 1, MKD_GITHUBTAGS },

--- a/tests/anchor.t
+++ b/tests/anchor.t
@@ -1,0 +1,81 @@
+. tests/functions.sh
+
+
+rc=0
+MARKDOWN_FLAGS=
+
+# new-style; uses a (depreciated) name=
+# inside a null <a> tag
+
+title "anchored table-of-contents support"
+
+try '-T -ftoc,taganchor' 'anchored table of contents' \
+'#H1
+hi' \
+'<ul>
+ <li><a href="#discount-H1">H1</a></li>
+</ul>
+<h1 id="discount-H1"><a class="anchor" href="#discount-H1"></a>H1</h1>
+
+<p>hi</p>'
+
+try '-T -ftoc,taganchor' 'toc anchored item with link' \
+'##[H2](H2) here' \
+'<ul>
+ <li>
+ <ul>
+  <li><a href="#discount-H2-here">H2 here</a></li>
+ </ul>
+ </li>
+</ul>
+<h2 id="discount-H2-here"><a class="anchor" href="#discount-H2-here"></a><a href="H2">H2</a> here</h2>'  
+
+try '-T -ftoc,taganchor' 'toc anchored item with non-alpha start' \
+'#1 header' \
+'<ul>
+ <li><a href="#discount-L1-header">1 header</a></li>
+</ul>
+<h1 id="discount-L1-header"><a class="anchor" href="#discount-L1-header"></a>1 header</h1>'
+
+# Be sure to save anchor.t as UTF-8.
+try '-T -ftoc,taganchor,html5anchor' 'anchored html5 multibyte chars' \
+'#It’s an apostrophe' \
+'<ul>
+ <li><a href="#discount-It’s-an-apostrophe">It’s an apostrophe</a></li>
+</ul>
+<h1 id="discount-It’s-an-apostrophe"><a class="anchor" href="#discount-It’s-an-apostrophe"></a>It’s an apostrophe</h1>'
+
+summary $0
+
+
+# Check that the uniquifier works
+#
+
+title "uniquifying anchored duplicate headers"
+
+
+try '-T -ftoc,taganchor' 'uniquifying anchored duplicate labels' \
+'# this
+# this' \
+'<ul>
+ <li><a href="#discount-this">this</a></li>
+ <li><a href="#discount-this_0">this</a></li>
+</ul>
+<h1 id="discount-this"><a class="anchor" href="#discount-this"></a>this</h1>
+
+<h1 id="discount-this_0"><a class="anchor" href="#discount-this_0"></a>this</h1>'
+  
+
+summary $0
+
+# Check that custom anchorid works
+#
+
+title "custom anchorid headings"
+
+try '-a test- -ftoc,taganchor' 'custom anchorid' \
+'# this' \
+'<h1 id="test-this"><a class="anchor" href="#test-this"></a>this</h1>'
+
+summary $0
+exit $rc

--- a/tests/codeblock.t
+++ b/tests/codeblock.t
@@ -265,5 +265,31 @@ content
 </p>'
 
 
+try -ffencedcode 'subitem fenced code' \
+'+ item
+  ```
+  code
+  ```' \
+'<ul>
+<li>item
+<pre><code>
+code
+</code></pre>
+</li>
+</ul>'
+
+
+try -ffencedcode 'subitem fenced code with class' \
+'+ item
+  ```class
+  code
+  ```' \
+'<ul>
+<li>item
+<pre><code class="class">
+code
+</code></pre>
+</li>
+</ul>'
 summary $0
 exit $rc

--- a/tests/exercisers/make.include
+++ b/tests/exercisers/make.include
@@ -4,7 +4,7 @@ EXERCISE=$(exercisers)/flags
 
 TESTFRAMEWORK += $(EXERCISE)
 
-$(exercisers)/flags: $(exercisers)/flags.o
+$(exercisers)/flags: $(exercisers)/flags.o libmarkdown
 	$(LINK) -o $@ $< -lmarkdown
 	
 $(exercisers)/flags.o: $(exercisers)/flags.c

--- a/tests/inlinefenced.t
+++ b/tests/inlinefenced.t
@@ -1,0 +1,262 @@
+. tests/functions.sh
+
+title "inlined fenced code blocks"
+
+try -ffencedinline 'inlined fenced code disabled backtick' \
+'```
+
+unrecognized code!
+```' \
+'<p>```</p>
+
+<p>unrecognized code!
+```</p>'
+
+try -ffencedinline 'inlined fenced code disabled backtick as inline code' \
+'```
+inline code?
+```' \
+'<p><code>
+inline code?
+</code></p>'
+
+try -ffencedinline 'inlined fenced code disabled tilde' \
+'~~~
+
+unrecognized code!
+~~~' \
+'<p>~~~</p>
+
+<p>unrecognized code!
+~~~</p>'
+
+try -ffencedcode,fencedinline 'inlined fenced code block with blank lines' \
+'~~~
+code!
+
+still code!
+~~~' \
+    '<p><pre><code>code!
+
+still code!
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block' \
+'~~~
+code!
+~~~' \
+    '<p><pre><code>code!
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block in list' \
+'1. ~~~
+code block
+~~~' \
+'<ol>
+<li><pre><code>code block
+</code></pre>
+</li>
+</ol>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block in blockquote' \
+'>~~~
+code
+~~~' \
+'<blockquote><p><pre><code>code
+</code></pre>
+</p></blockquote>'
+
+try  -ffencedcode,fencedinline 'unterminated inlined fenced code block' \
+'~~~
+code' \
+'<p>~~~
+code</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with tildes' \
+'~~~~~
+~~~
+code with tildes
+~~~
+~~~~~' \
+'<p><pre><code>~~~
+code with tildes
+~~~
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'paragraph with trailing inlined fenced block' \
+'text text text
+text text text
+~~~
+code code code?
+~~~' \
+'<p>text text text
+text text text
+<pre><code>code code code?
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code blocks with backtick delimiters' \
+'```
+code
+```' \
+'<p><pre><code>code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with mismatched delimters' \
+'```
+code
+~~~' \
+'<p>```
+code
+~~~</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang attribute' \
+'```lang
+code
+```' \
+'<p><pre><code class="lang">code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang-name attribute' \
+'```lang-name
+code
+```' \
+'<p><pre><code class="lang-name">code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang_name attribute' \
+'```lang_name
+code
+```' \
+'<p><pre><code class="lang_name">code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang attribute and space' \
+'``` lang
+code
+```' \
+'<p><pre><code class="lang">code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang attribute and multiple spaces' \
+'```       lang
+code
+```' \
+'<p><pre><code class="lang">code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang-name attribute and space' \
+'``` lang-name
+code
+```' \
+'<p><pre><code class="lang-name">code
+</code></pre>
+</p>'
+
+try  -ffencedcode,fencedinline 'inlined fenced code block with lang_name attribute and space' \
+'``` lang_name
+code
+```' \
+'<p><pre><code class="lang_name">code
+</code></pre>
+</p>'
+
+try -ffencedcode,fencedinline 'inlined fenced code block with blank line in the middle' \
+'```
+hello
+
+sailor
+```' \
+'<p><pre><code>hello
+
+sailor
+</code></pre>
+</p>'
+
+
+try -ffencedcode,fencedinline 'inlined fenced code block with html in the middle' \
+'~~~~
+<h1>hello, sailor</h1>
+~~~~' \
+'<p><pre><code>&lt;h1&gt;hello, sailor&lt;/h1&gt;
+</code></pre>
+</p>'
+
+try -ffencedcode,fencedinline 'inlined fenced code block with trailing spaces in list item' \
+'1.  ~~~~    
+    test me
+    ~~~~' \
+'<ol>
+<li><pre><code>test me
+</code></pre>
+</li>
+</ol>'
+
+try -ffencedcode,fencedinline 'inlined unterminated fenced code block' \
+'~~~~
+foo' \
+'<p>~~~~
+foo</p>'
+
+try -ffencedcode,fencedinline 'paragraph, then inlined code block' \
+'foo
+
+~~~~
+bar
+~~~~' \
+'<p>foo</p>
+
+<p><pre><code>bar
+</code></pre>
+</p>'
+
+
+try -ffencedcode,fencedinline 'checkline misparse as inlined fenced code' \
+'[`label`](#code)
+```class
+content
+```
+' \
+'<p><a href="#code"><code>label</code></a>
+<pre><code class="class">content
+</code></pre>
+</p>'
+
+
+try -ffencedcode,fencedinline 'subitem inlined fenced code' \
+'+ item
+  ```
+  code
+  ```' \
+'<ul>
+<li>item
+<pre><code>code
+</code></pre>
+</li>
+</ul>'
+
+
+try -ffencedcode,fencedinline 'subitem inlined fenced code with class' \
+'+ item
+  ```class
+  code
+  ```' \
+'<ul>
+<li>item
+<pre><code class="class">code
+</code></pre>
+</li>
+</ul>'
+
+
+summary $0
+exit $rc


### PR DESCRIPTION
Hi, here's a small list of patches I've added for my use case. Feel free to ignore or cherrypick, I'll just post these here in case anyone else finds them useful.

# List of commits:

1. improve parallel compilation

   GNU Make run in palallel complains about `libmarkdown` missing, apparently because the tests were trying to build before the library. Fixes that issue.

2. add hopthelp

   Adds `markdown -h` as a legitimate option that just dumps the flags and their descriptions before exiting.

3. add taganchor option

   The `-ftaganchor` flag outputs anchors with inline NULL `<a class="anchor">` tags, similar to the default behaviour, but they're inside the heading and the heading IDs get applied a prefix. This more or less guarantees that there can be no accidental CSS pickups, as long as I make sure to not use that prefix in my CSS.
   
   Also adds the `-a` flag, which sets the prefix to be used.
   
   With these these options, I am able to generate something very close to GitHub/GitLab READMEs, with headings that have a link button that appears when hovering with the following CSS:
   ```
   .anchor::before {
	content: "🔗";
	margin-right: 0.5em;
	font-size: 12pt;
   }
   
   .anchor {
	visibility: hidden;
   }
   
   h1:hover .anchor,
   h2:hover .anchor,
   h3:hover .anchor,
   h4:hover .anchor,
   h5:hover .anchor,
   h6:hover .anchor {
	visibility: visible;
   }
   ```

4. add fencedinline option

   Currently when using `-ffencedcode` there's a newline that is added after the `<pre><code>` combo, which results in a somewhat ugly forehead when combined with a background color, for example. This flag removes that newline, giving me nice and slim fenced code blocks, again very close to what GitHub/GitLab renders.