### PR TITLE
Clang fixes

### DIFF
--- a/configure.inc
+++ b/configure.inc
@@ -205,8 +205,8 @@ AC_CHECK_FUNCS () {
     B=`echo "$1" | sed -e 's/(.*)//'`
 
     case "$B" in
-    "$1") F="$1()"; need_proto=1 ;;
-    *)    F="$1"  ; unset need_proto ;;
+    "$1") F="$1()"; PROTO="$1(void)"; need_proto=1 ;;
+    *)    F="$1"  ; unset PROTO; unset need_proto ;;
     esac
 
     shift
@@ -218,11 +218,11 @@ AC_CHECK_FUNCS () {
     done
 
     if [ "$need_proto" ]; then
-	echo "void $F;" >> ngc$$.c
+	echo "void $PROTO;" >> ngc$$.c
     fi
 
     cat >> ngc$$.c << EOF
-int main()
+int main(void)
 {
 
     $F;
@@ -263,7 +263,7 @@ AC_CHECK_STRUCT () {
     done
 
     cat >> ngc$$.c << EOF
-int main()
+int main(void)
 {
     struct $struct foo;
 }
@@ -298,7 +298,7 @@ AC_CHECK_TYPE () {
     done
 
     cat >> ngc$$.c << EOF
-int main()
+int main(void)
 {
     $type foo;
 }
@@ -335,7 +335,7 @@ AC_CHECK_FIELD () {
     done
 
     cat >> ngc$$.c << EOF
-int main()
+int main(void)
 {
     struct $struct foo;
 
@@ -364,8 +364,8 @@ AC_PROG_CC () {
     test "$AC_CC" && return 0
 
     cat > ngc$$.c << \EOF
-extern void say(void*);
-int main()
+void say(char*);
+int main(void)
 {
     say("hello, sailor");
 }
@@ -899,7 +899,7 @@ EOF
 # AC_C_VOLATILE checks to see if the compiler supports the volatile keyword
 #
 AC_C_VOLATILE () {
-    echo 'f() { volatile char me=1; }' > ngc$$.c
+    echo 'void f(void) { volatile char me=1; }' > ngc$$.c
     LOGN "checking for \"volatile\" keyword"
 
     if __MAKEDOTO ngc$$.c; then
@@ -917,7 +917,7 @@ AC_C_VOLATILE () {
 # AC_C_INLINE checks to see if compiler supports the inline keyword
 #
 AC_C_INLINE() {
-    echo 'inline int foo() { return 1; }' > ngc$$.c
+    echo 'inline int foo(void) { return 1; }' > ngc$$.c
     LOGN 'Checking for "inline" keyword'
     if __MAKEDOTO ngc$$.c; then
 	rc=0
@@ -956,7 +956,7 @@ AC_WHATIS() {
 	    echo "#include <${x}>"
 	done
 
-	echo "main() { printf(\"${MACRO}=\\\"${__fmt}\\\"\\n\", ${MACRO}); }" )  > _ngc$$.c
+	echo "int main(void) { printf(\"${MACRO}=\\\"${__fmt}\\\"\\n\", ${MACRO}); }" )  > _ngc$$.c
 
     if $AC_CC $AC_CFLAGS -o _ngc$$ _ngc$$.c; then
 	./_ngc$$
@@ -1037,8 +1037,7 @@ say(char *w, char *v)
 }
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     unsigned long v_long;
     unsigned int v_int;
@@ -1227,7 +1226,7 @@ AC_CHECK_FLOCK() {
 #include <sys/types.h>
 #include <fcntl.h>
 
-int main()
+int main(void)
 {
     int x = open("ngc$$.c", O_RDWR, 0666);
     int y = open("ngc$$.c", O_RDWR, 0666);
@@ -1281,7 +1280,7 @@ AC_CHECK_RESOLVER () {
 #include <arpa/nameser.h>
 #include <resolv.h>
 
-int main()
+int main(void)
 {
     char bfr[256];
 
@@ -1325,7 +1324,7 @@ AC_CHECK_ALLOCA () {
 #else
 # include <stdlib.h>
 #endif
-int main()
+int main(void)
 {
 	alloca(10);
 }
@@ -1361,7 +1360,7 @@ AC_CHECK_BASENAME() {
 
 extern char *basename(char*);
 
-int main()
+int main(void)
 {
     char *a = basename("/a/test");
     char *b = basename("/a/nother");
@@ -1592,7 +1591,11 @@ AC_PROG_INSTALL () {
     fi
 
     # see if we can strip binaries
-    echo 'main() { puts("hello, sailor!"); }' > ngc$$.c
+    cat > ngc$$.c << EOF
+#include <stdio.h>
+int main(void) { puts("hello, sailor!"); }
+EOF
+
     if $AC_CC -o ngc$$ ngc$$.c; then
 	if $PROG_INSTALL -s -m 444 ngc$$ inst$$; then
 	    _strip="-s"
@@ -1747,9 +1750,7 @@ cat > ngc$$.c << \EOF
 #include <stdio.h>
 
 int
-main(argc, argv)
-int argc;
-char **argv;
+main(int argc, char **argv)
 {
     char *p;
     

--- a/configure.sh
+++ b/configure.sh
@@ -134,8 +134,7 @@ if AC_CHECK_HEADERS sys/stat.h && AC_CHECK_FUNCS stat; then
 cat > ngc$$.c << EOF
 #include <sys/stat.h>
 
-main(argc, argv)
-char **argv;
+int main(int argc, char **argv)
 {
    struct stat info;
 

--- a/flags.c
+++ b/flags.c
@@ -105,7 +105,7 @@ mkd_init_flags(mkd_flag_t *p)
 }
 
 mkd_flag_t *
-mkd_flags()
+mkd_flags(void)
 {
     mkd_flag_t *p = malloc( sizeof(mkd_flag_t) );
 

--- a/generate.c
+++ b/generate.c
@@ -638,8 +638,7 @@ printlinkyref(MMIOT *f, linkytype *tag, char *link, int size)
  * define a prefix tag instead of just `fn`
  */
 static char *
-p_or_nothing(p)
-MMIOT *p;
+p_or_nothing(MMIOT *p)
 {
     return p->ref_prefix ? p->ref_prefix : "fn";
 }

--- a/gethopt.3
+++ b/gethopt.3
@@ -157,8 +157,7 @@ struct h_opt opts[] = {
 
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     struct h_opt *ret;
     struct h_context ctx;

--- a/gethopt.c
+++ b/gethopt.c
@@ -10,10 +10,7 @@
 
 
 void
-hoptset(ctx, argc, argv)
-struct h_context *ctx;
-int argc;
-char **argv;
+hoptset(struct h_context *ctx, int argc, char **argv)
 {
     memset(ctx, 0, sizeof *ctx);
     ctx->argc = argc;
@@ -23,30 +20,26 @@ char **argv;
 
 
 char *
-hoptarg(ctx)
-struct h_context *ctx;
+hoptarg(struct h_context *ctx)
 {
     return ctx->optarg;
 }
 
 int
-hoptind(ctx)
-struct h_context *ctx;
+hoptind(struct h_context *ctx)
 {
     return ctx->optind;
 }
 
 char
-hoptopt(ctx)
-struct h_context *ctx;
+hoptopt(struct h_context *ctx)
 {
     return ctx->optopt;
 }
 
 
 int
-hopterr(ctx,val)
-struct h_context *ctx;
+hopterr(struct h_context *ctx, int val)
 {
     int old = ctx->opterr;
 
@@ -56,10 +49,7 @@ struct h_context *ctx;
 
 
 struct h_opt *
-gethopt(ctx, opts, nropts)
-struct h_context *ctx;
-struct h_opt *opts;
-int nropts;
+gethopt(struct h_context *ctx, struct h_opt *opts, int nropts)
 {
     int i;
     int dashes;
@@ -318,8 +308,7 @@ struct h_opt opts[] = {
 
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     struct h_opt *ret;
     struct h_context ctx;

--- a/html5.c
+++ b/html5.c
@@ -3,7 +3,7 @@
 #include "tags.h"
 
 void
-mkd_with_html5_tags()
+mkd_with_html5_tags(void)
 {
     static int populated = 0;
 

--- a/makepage.c
+++ b/makepage.c
@@ -30,9 +30,7 @@ struct h_opt opts[] = {
 #define NROPTS (sizeof opts / sizeof opts[0])
 
 int
-main(argc, argv)
-int argc;
-char **argv;
+main(int argc, char **argv)
 {
     MMIOT *doc;
     char *q;

--- a/markdown.h
+++ b/markdown.h
@@ -265,8 +265,8 @@ extern Document *mkd_string(const char*, int, mkd_flag_t*);
 extern Document *gfm_in(FILE *, mkd_flag_t*);
 extern Document *gfm_string(const char*,int, mkd_flag_t*);
 
-extern void mkd_initialize();
-extern void mkd_shlib_destructor();
+extern void mkd_initialize(void);
+extern void mkd_shlib_destructor(void);
 
 extern void mkd_ref_prefix(Document*, char*);
 
@@ -285,7 +285,7 @@ extern void ___mkd_reparse(char *, int, mkd_flag_t*, MMIOT*, char*);
 extern void ___mkd_emblock(MMIOT*);
 extern void ___mkd_tidy(Cstring *);
 
-extern Document *__mkd_new_Document();
+extern Document *__mkd_new_Document(void);
 extern void __mkd_enqueue(Document*, Cstring *);
 extern void __mkd_trim_line(Line *, int);
 

--- a/mkd2html.c
+++ b/mkd2html.c
@@ -85,8 +85,7 @@ extern char* mkd_h1_title(MMIOT *);
 
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     char *h;
     char *source = 0, *dest = 0;

--- a/mkdio.c
+++ b/mkdio.c
@@ -20,7 +20,7 @@ typedef ANCHOR(Line) LineAnchor;
 /* create a new blank Document
  */
 Document*
-__mkd_new_Document()
+__mkd_new_Document(void)
 {
     Document *ret = calloc(sizeof(Document), 1);
 

--- a/mkdio.h.in
+++ b/mkdio.h.in
@@ -47,7 +47,7 @@ typedef void mkd_flag_t;
 
 int mkd_flag_isset(mkd_flag_t*, int);		/* check a flag status */
 
-mkd_flag_t *mkd_flags();			/* create a flag blob */
+mkd_flag_t *mkd_flags(void);			/* create a flag blob */
 mkd_flag_t *mkd_copy_flags(mkd_flag_t*);	/* copy a flag blob */
 void mkd_free_flags(mkd_flag_t*);		/* delete a flag blob */
 char *mkd_set_flag_string(mkd_flag_t*, char*);	/* set named flags */
@@ -83,9 +83,9 @@ MMIOT *gfm_string(const char*,int,mkd_flag_t*);	/* assemble input from a buffer 
 
 void mkd_basename(MMIOT*,char*);
 
-void mkd_initialize();
-void mkd_with_html5_tags();
-void mkd_shlib_destructor();
+void mkd_initialize(void);
+void mkd_with_html5_tags(void);
+void mkd_shlib_destructor(void);
 
 /* compilation, debugging, cleanup
  */

--- a/mktags.c
+++ b/mktags.c
@@ -43,7 +43,7 @@ typedef int (*stfu)(const void*,const void*);
 /* load in the standard collection of html tags that markdown supports
  */
 int
-main()
+main(void)
 {
     int i;
 

--- a/notspecial.c
+++ b/notspecial.c
@@ -33,8 +33,7 @@ notspecial(char *file)
 #include <stdio.h>
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     int i;
 

--- a/setup.c
+++ b/setup.c
@@ -21,7 +21,7 @@
 static int need_to_initrng = 1;
 
 void
-mkd_initialize()
+mkd_initialize(void)
 {
 
     if ( need_to_initrng ) {
@@ -32,7 +32,7 @@ mkd_initialize()
 
 
 void DESTRUCTOR
-mkd_shlib_destructor()
+mkd_shlib_destructor(void)
 {
     mkd_deallocate_tags();
 }

--- a/tags.c
+++ b/tags.c
@@ -59,7 +59,7 @@ typedef int (*stfu)(const void*,const void*);
 /* sort the list of extra html block tags for later searching
  */
 void
-mkd_sort_tags()
+mkd_sort_tags(void)
 {
     qsort(T(extratags), S(extratags), sizeof(struct kw), (stfu)casort);
 }
@@ -89,7 +89,7 @@ mkd_search_tags(char *pat, int len)
 /* destroy the extratags list (for shared libraries)
  */
 void
-mkd_deallocate_tags()
+mkd_deallocate_tags(void)
 {
     if ( S(extratags) > 0 )
 	DELETE(extratags);

--- a/tags.h
+++ b/tags.h
@@ -11,9 +11,9 @@ struct kw {
 
 
 struct kw* mkd_search_tags(char *, int);
-void mkd_prepare_tags();
-void mkd_deallocate_tags();
-void mkd_sort_tags();
+void mkd_prepare_tags(void);
+void mkd_deallocate_tags(void);
+void mkd_sort_tags(void);
 void mkd_define_tag(char *, int);
 
 #endif

--- a/tests/exercisers/flags.c
+++ b/tests/exercisers/flags.c
@@ -11,7 +11,7 @@ say(char *what)
 
 
 int
-main()
+main(void)
 {
     mkd_flag_t *flags = mkd_flags();
 

--- a/theme.c
+++ b/theme.c
@@ -192,7 +192,7 @@ prepare(FILE *input)
 }
 
 static int
-pull()
+pull(void)
 {
     return psp < S(inbuf) ? T(inbuf)[psp++] : EOF;
 }
@@ -216,7 +216,7 @@ shift(int shiftwidth)
 }
 
 static int*
-cursor()
+cursor(void)
 {
     return T(inbuf) + psp;
 }
@@ -549,8 +549,7 @@ struct h_opt opts[] = {
 #define NROPTS (sizeof opts / sizeof opts[0])
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     char *template = "page.theme";
     char *source = "stdin";

--- a/tools/branch.c
+++ b/tools/branch.c
@@ -4,9 +4,7 @@
 #include "config.h"
 
 int
-main(argc, argv)
-int argc;
-char **argv;
+main(int argc, char **argv)
 {
 #if HAS_GIT
     FILE * pipe;

--- a/tools/cols.c
+++ b/tools/cols.c
@@ -2,8 +2,7 @@
 #include <stdlib.h>
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     register int c;
     int xp;

--- a/tools/echo.c
+++ b/tools/echo.c
@@ -4,8 +4,7 @@
 
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     int nl = 1;
     int i;

--- a/tools/pandoc_headers.c
+++ b/tools/pandoc_headers.c
@@ -50,8 +50,7 @@ struct h_opt opts[] = {
 #define NROPTS (sizeof opts / sizeof opts[0])
 
 int
-main(argc, argv)
-char **argv;
+main(int argc, char **argv)
 {
     int show_author=0, show_title=0, show_date=0;
     MMIOT *p;

--- a/tools/space2nl.c
+++ b/tools/space2nl.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 int
-main()
+main(void)
 {
     register int c;
 

--- a/xmlpage.c
+++ b/xmlpage.c
@@ -34,8 +34,9 @@ mkd_xhtmlpage(Document *p, mkd_flag_t* flags, FILE *out)
 	DO_OR_DIE( fprintf(out, "<head>\n") );
 	DO_OR_DIE( fprintf(out, "<title>") );
 	
-	if ( title = DOCUMENT_TITLE(p) )
+	if ( title = DOCUMENT_TITLE(p) ) {
 	    DO_OR_DIE( fprintf(out, "%s", title) );
+	}
 	DO_OR_DIE( fprintf(out, "</title>\n") );
 	DO_OR_DIE( mkd_generatecss(p, out) );
 	DO_OR_DIE( fprintf(out, "</head>\n"


### PR DESCRIPTION
Make C99 clean

* Clang 16 (and likely GCC 14) will enforce strict C99 semantics and break old K&R C declarations and require correct C89 function prototypes.

Bug: https://bugs.gentoo.org/870952
Clang: https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213/9