### PR TITLE
tools/rep.c: add strlen() function declaration

### DIFF
--- a/tools/rep.c
+++ b/tools/rep.c
@@ -3,7 +3,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
+#include <string.h>
 
 
 char *


### PR DESCRIPTION
Upcoming `gcc-14` will enable some warnings as error by default. One of them is `-Wimplicit-function-declaration`:

    tools/rep.c: In function 'deformat':
    tools/rep.c:12:30: error: implicit declaration of function 'strlen' [-Wimplicit-function-declaration]
       12 |     char *ptr, *new = calloc(strlen(s)+1, 1);
          |                              ^~~~~~
    tools/rep.c:7:1: note: include '<string.h>' or provide a declaration of 'strlen'
        6 | #include <strings.h>
      +++ |+#include <string.h>
        7 |

The change uses standard `<string.h>` header for `strlen()` declaration.