### PR TITLE
Fix memory leak in mkd_xml()

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -79,5 +79,7 @@ mkd_xml(char *p, int size, char **res)
      */
     EXPAND(f) = 0;
     *res = strdup(T(f));
-    return S(f)-1;
+    size = S(f)-1;
+    DELETE(f);
+    return size;
 }


### PR DESCRIPTION
The `Cstring` `f` wasn't being `DELETE()`d before returning from `mkd_xml()`, leading to a leak every time it was called.