### PR TITLE
Make fallthrough explicit in emmatch.c

### DIFF
--- a/emmatch.c
+++ b/emmatch.c
@@ -110,8 +110,10 @@ emmatch(MMIOT *f, int first, int last)
     int e, e2, match;
 
     switch (start->b_count) {
-    case 2: if ( e = empair(f,first,last,match=2) )
-		break;
+    case 2: 
+	    if ( e = empair(f,first,last,match=2) ) { break; }
+	    // If 2 char match doesn't work, try a 1 char match
+	    __attribute__((fallthrough)); 
     case 1: e = empair(f,first,last,match=1);
 	    break;
     case 0: return;


### PR DESCRIPTION
`__attribute__((fallthrough))` makes the code compatible with `-Wimplicit-fallthrough`, which can prevent many bugs.

If older compilers need support the following macro can help:
```
#ifndef deliberate_fall_through
#  if defined __has_attribute
#    if __has_attribute (fallthrough)
#      define deliberate_fall_through __attribute__ ((fallthrough))
#    else
#      define deliberate_fall_through
#    endif
#  else
#    define deliberate_fall_through
#  endif
#endif
```

Note that there is a similar issue [here](https://github.com/Orc/discount/blob/5e2f73aec4025b23a6d1c85b6c62f9653cccd9b9/generate.c#L1440).