### PR TITLE
Ensure null termination of extended_attrs, width and height

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -430,6 +430,12 @@ linkysize(MMIOT *f, Footnote *ref)
 		c = eatspace(f);
 
 	    if ( (c == ')') || ((c == '\'' || c == '"') && linkytitle(f, c, ref)) ) {
+		/* add null bytes but pretend they don't exist. */
+		EXPAND(height) = 0;
+		--S(height);
+		EXPAND(width) = 0;
+		--S(width);
+
 		ref->height = height;
 		ref->width  = width;
 		return 1;

--- a/markdown.c
+++ b/markdown.c
@@ -1172,6 +1172,7 @@ addfootnote(Line *p, MMIOT* f)
 	if ( T(p->text)[i] == '}' ) {
 	    for ( j++; j < i; j++ )
 		EXPAND(foot->extended_attr) = T(p->text)[j];
+	    EXPAND(foot->extended_attr) = 0;
 	    j++;
 	}
     }

--- a/resource.c
+++ b/resource.c
@@ -107,6 +107,7 @@ ___mkd_initmmiot(MMIOT *f, void *footnotes, mkd_flag_t *flags)
 	    f->footnotes = footnotes;
 	else {
 	    f->footnotes = malloc(sizeof f->footnotes[0]);
+	    f->footnotes->reference = 0;
 	    CREATE(f->footnotes->note);
 	}
 	if ( flags )


### PR DESCRIPTION
This PR contains a follow-up for eda57f596d3f09feed092634256a9e991151f49f, improving null-termination for extended attributes. Further, it ensures zero initialization of the reference counter used for footnotes. Lastly, it fixes out-of-bounds reads caused by lack of string null termination in the changes added in 6ff6878cfdb76733c95a99e6f24743976ff82c7e (which made width/height a string but didn't ensure their null termination).

Since the generator uses the `S(<field>) > 0` idiom to check for their presence, and I didn't want to modify these checks, I used a trick I discovered [elsewhere in the codebase](https://github.com/Orc/discount/blob/8ddfb981eff89b4e76d71e7203af5d0975b63eda/generate.c#L2150-L2154) to exclude them from the size count. Let me know if you prefer a different solution.

Fixes #298