### PR TITLE
Fixes for code block formatter in version 2.x

### DIFF
--- a/main.c
+++ b/main.c
@@ -126,13 +126,13 @@ external_codefmt(const char *src, const int len, void *ext_lang)
     x = strlen(res);
     for ( i=0; i < len; i++ ) {
 	switch (src[i]) {
-	case '&':   strcpy(&src[x], "&amp;");
+	case '&':   strcpy(&res[x], "&amp;");
 		    x += 5 /*strlen(&amp;)*/ ;
 		    break;
-	case '<':   strcpy(&src[x], "&lt;");
+	case '<':   strcpy(&res[x], "&lt;");
 		    x += 4 /*strlen(&lt;)*/ ;
 		    break;
-	case '>':   strcpy(&src[x], "&gt;");
+	case '>':   strcpy(&res[x], "&gt;");
 		    x += 4 /*strlen(&gt;)*/ ;
 		    break;
 	default:    res[x++] = src[i];

--- a/main.c
+++ b/main.c
@@ -100,8 +100,9 @@ free_it(char *object, void *ctx)
 }
 
 char *
-external_codefmt(char *src, int len, char *lang)
+external_codefmt(const char *src, const int len, void *ext_lang)
 {
+    char *lang = (char*)ext_lang;
     int extra = 0;
     int i, x;
     char *res;


### PR DESCRIPTION
Fixes two issues with `external_codefmt` in the 2.x release series:

- Function signature causing an incompatible pointer type error during compilation using GCC 15.2.0 with `-Wincompatible-pointer-types`.
- Logic error causing special character replacements to be copied to the source buffer instead of the result buffer.

The specific compilation error is:

```make
$ make
cc -Wno-return-type -Wno-implicit-int -I. -g -c main.c
main.c: In function ‘main’:
main.c:311:36: error: passing argument 2 of ‘mkd_e_code_format’ from incompatible pointer type [-Wincompatible-pointer-types]
  311 |             mkd_e_code_format(doc, external_codefmt);
      |                                    ^~~~~~~~~~~~~~~~
      |                                    |
      |                                    char * (*)(char *, int,  char *)
In file included from main.c:12:
./mkdio.h:71:31: note: expected ‘mkd_callback_t’ {aka ‘char * (*)(const char *, const int,  void *)’} but argument is of type ‘char * (*)(char *, int,  char *)’
   71 | void mkd_e_code_format(void*, mkd_callback_t);
      |                               ^~~~~~~~~~~~~~
main.c:103:1: note: ‘external_codefmt’ declared here
  103 | external_codefmt(char *src, int len, char *lang)
      | ^~~~~~~~~~~~~~~~
./mkdio.h:65:18: note: ‘mkd_callback_t’ declared here
   65 | typedef char * (*mkd_callback_t)(const char*, const int, void*);
      |                  ^~~~~~~~~~~~~~
make: *** [Makefile:127: main.o] Error 1
```